### PR TITLE
Removed/fixed code causing compiler warnings.

### DIFF
--- a/ExCSS/Model/Selector/SelectorList.cs
+++ b/ExCSS/Model/Selector/SelectorList.cs
@@ -52,6 +52,6 @@ namespace ExCSS
             return ((IEnumerable)Selectors).GetEnumerator();
         }
 
-        public abstract string ToString(bool friendlyFormat, int indentation = 0);
+        public override abstract string ToString(bool friendlyFormat, int indentation = 0);
     }
 }

--- a/ExCSS/Model/Selector/SimpleSelector.cs
+++ b/ExCSS/Model/Selector/SimpleSelector.cs
@@ -1,18 +1,17 @@
-﻿using ExCSS.Model;
+﻿using System;
+using ExCSS.Model;
 // ReSharper disable once CheckNamespace
-
 
 namespace ExCSS
 {
     public class SimpleSelector
     {
-        private static readonly SimpleSelector GlobalSelector = new SimpleSelector();
         private readonly string _code;
-        internal static readonly SimpleSelector All = new SimpleSelector();
+        internal static readonly SimpleSelector All = new SimpleSelector("*");
 
-        public SimpleSelector()
+        protected SimpleSelector()
         {
-            _code = "*";
+            //Leave _code = null
         }
 
         public SimpleSelector(string selectorText)
@@ -131,6 +130,8 @@ namespace ExCSS
 
         public virtual string ToString(bool friendlyFormat, int indentation = 0)
         {
+            if (_code == null)
+                throw new InvalidOperationException();
             return _code;
         }
     }

--- a/ExCSS/StylesheetReader.cs
+++ b/ExCSS/StylesheetReader.cs
@@ -14,11 +14,9 @@ namespace ExCSS
         private TextReader _reader;
         private readonly StringBuilder _buffer;
         private bool _lineWithReturn;
-        private Encoding _encoding;
 
         StylesheetReader()
         {
-            _encoding = HtmlEncoding.Suggest(CultureInfo.CurrentUICulture.Name);
             _buffer = new StringBuilder();
             _collengths = new Stack<int>();
             Column = 1;


### PR DESCRIPTION
Warnings about unused variables and missing override.
Changed SimpleSelector constructor so no inherited classes accidentally would get _code="*"

The missing override caused some subclasses of SimpleSelector to generate the code "*".
The changes in SimpleSelector is to catch any future errors of that kind.
