### PR TITLE
fix for issue: Parser fails on inherit value #30

### DIFF
--- a/ExCSS/Parser.Blocks.cs
+++ b/ExCSS/Parser.Blocks.cs
@@ -542,8 +542,7 @@ namespace ExCSS
             {
                 return AddTerm(new PrimitiveTerm(UnitType.Ident, token.Value));
             }
-
-            _property.Term = Term.Inherit;
+            _terms.AddTerm(Term.Inherit);
             SetParsingContext(ParsingContext.AfterValue);
             return true;
         }


### PR DESCRIPTION
Setting the Term on Property directly caused a failure when the Property finalizes. See the issue Parser fails on inherit value #30. This change adds to the TermList where it will populate the Property's Term upon FinalizeProperty().
