### PR TITLE
Align assembly verions with package release 2.0.3

### DIFF
--- a/ExCSS/Properties/AssemblyInfo.cs
+++ b/ExCSS/Properties/AssemblyInfo.cs
@@ -30,5 +30,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("2.0.2")]
-[assembly: AssemblyFileVersion("2.0.2")]
+[assembly: AssemblyVersion("2.0.3")]
+[assembly: AssemblyFileVersion("2.0.3")]


### PR DESCRIPTION
Current NuGet package release is at 2.0.3 (https://www.nuget.org/packages/ExCSS/2.0.3) but the assembly version attributes still reflect version 2.0.2.
