### PR TITLE
Fixes for "background gradients #26". 

### DIFF
--- a/ExCSS.Tests/PropertyFixture.cs
+++ b/ExCSS.Tests/PropertyFixture.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 
 namespace ExCSS.Tests
 {
@@ -22,6 +23,39 @@ namespace ExCSS.Tests
             var colorString = color.ToString(true, false);
 
             Assert.AreEqual(colorString.Length, 7);
+        }
+
+        [Test]
+        public void Converts_Rgb_To_Hex()
+        {
+            var parser = new Parser();
+            var css = parser.Parse(".class{color:rgb(10,255,34);");
+            Assert.AreEqual(".class{color:#0AFF22;}", css.ToString());
+        }
+
+
+        [Test]
+        public void Converts_Rgba_With_Opacity_To_Hex()
+        {
+            var parser = new Parser();
+            var css = parser.Parse(".class{color:rgba(10, 255,34, 0.4);");
+            Assert.AreEqual(".class{color:rgba(10,255,34,0.4);}", css.ToString());
+        }
+
+        [Test]
+        public void Converts_Rgba_To_Hex()
+        {
+            var parser = new Parser();
+            var css = parser.Parse(".class{color:rgba(255, 0,    255, 1);");
+            Assert.AreEqual(".class{color:#F0F;}", css.ToString());
+        }
+
+        [Test]
+        public void Converts_Hsl_To_Hex()
+        {
+            var parser = new Parser();
+            var css = parser.Parse(".class{color:hsl(0, 100,50);");
+            Assert.AreEqual(".class{color:#F2AAA9;}", css.ToString());
         }
     }
 }

--- a/ExCSS.Tests/SelectorFixture.cs
+++ b/ExCSS.Tests/SelectorFixture.cs
@@ -1,6 +1,4 @@
-﻿
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using NUnit.Framework;
 
 namespace ExCSS.Tests
@@ -452,6 +450,76 @@ namespace ExCSS.Tests
             Assert.AreEqual("#sidebar{}", stylesheet.Rules[0].ToString());
             Assert.AreEqual("#footer{}", stylesheet.Rules[1].ToString());
             Assert.AreEqual("#copyright{}", stylesheet.Rules[2].ToString());
+        }
+
+
+
+        [Test]
+        public void Parser_Reads_Background_Gradients()
+        {
+            var parser = new Parser();
+            var css = parser.Parse(@".bg{background:-moz-linear-gradient(top, #FFF 0, #FFF 100%) !important;}");
+
+            Assert.That(css.Errors.Count == 0);
+            Assert.AreEqual(1, css.Rules.Count());
+            Assert.AreEqual(@".bg{background:-moz-linear-gradient(top,#FFF 0,#FFF 100%) !important;}", css.Rules[0].ToString());
+        }
+
+        [Test]
+        public void Parser_Reads_Background_Gradients_With_Nested_RGBA()
+        {
+            var parser = new Parser();
+            var css = parser.Parse(@".bg{background: -moz-linear-gradient(left,     rgba(0, 119, 152,     1) 0%,        rgba(1,160, 155,1) 100%);}");
+            var cssResult = css.Rules[0].ToString();
+
+            Assert.That(css.Errors.Count == 0);
+            Assert.AreEqual(@".bg{background:-moz-linear-gradient(left,#007798 0%,#01A09B 100%);}", cssResult);
+        }
+
+        [Test]
+        public void Parser_Reads_Background_Gradients_Many()
+        {
+            var parser = new Parser();
+            var css = parser.Parse(@".group-sticker .no-override:hover:before,
+                    .group-sticker .no-override.on:before {
+                      z-index: 2;
+                      border-radius: 100%;
+                      background: #9ACE48 !important;
+                      background: -webkit-gradient(linear, left top, left bottom, color-stop(0, #9ACE48), color-stop(100%, #84B23C)) !important;
+                      background: -moz-linear-gradient(left, rgba(0,119,152,1) 0%, rgba(1,160,155,1) 100%);
+                      background: -webkit-gradient-linear(left top, left bottom, color-stop(0, #9ACE48), color-stop(100%, #84B23C)) !important;
+                      background: -webkit-linear-gradient(top, #9ACE48 0, #84B23C 100%) !important;
+                      background: -o-linear-gradient(top, #9ACE48 0, #84B23C 100%) !important;
+                      background: -ms-linear-gradient(top, #9ACE48 0, #84B23C 100%) !important;
+                      background: linear-gradient(to bottom, #9ACE48 0, #84B23C 100%) !important;
+                    }");
+            var cssResult = css.Rules[0].ToString();
+
+            Assert.That(css.Errors.Count == 0);
+            Assert.AreEqual(@".group-sticker .no-override:hover:before,.group-sticker .no-override.on:before{z-index:2;border-radius:100%;background:#9ACE48 !important;background:-webkit-gradient(linear,left top,left bottom,color-stop(0,#9ACE48),color-stop(100%,#84B23C)) !important;background:-moz-linear-gradient(left,#007798 0%,#01A09B 100%);background:-webkit-gradient-linear(left top,left bottom,color-stop(0,#9ACE48),color-stop(100%,#84B23C)) !important;background:-webkit-linear-gradient(top,#9ACE48 0,#84B23C 100%) !important;background:-o-linear-gradient(top,#9ACE48 0,#84B23C 100%) !important;background:-ms-linear-gradient(top,#9ACE48 0,#84B23C 100%) !important;background:linear-gradient(to bottom,#9ACE48 0,#84B23C 100%) !important;}", cssResult);
+        }
+
+        [Test]
+        public void Parser_Reads_Background_Gradients_With_Legacy_Syntax()
+        {
+            var parser = new Parser();
+            var css = parser.Parse(@".c{background: -webkit-gradient(linear, left top, left bottom, color-stop(0, #9ACE48), color-stop(100%, #84B23C)) !important;}");
+            var cssResult = css.Rules[0].ToString();
+
+            Assert.That(css.Errors.Count == 0);
+            Assert.AreEqual(@".c{background:-webkit-gradient(linear,left top,left bottom,color-stop(0,#9ACE48),color-stop(100%,#84B23C)) !important;}", cssResult);
+        }
+
+
+        [Test]
+        public void Parser_Reads_Background_Gradients_With_Nested_Fn()
+        {
+            var parser = new Parser();
+            var css = parser.Parse(@".c{background:-webkit-gradient(linear, left top, left bottom, color-stop(0, #9ACE48), color-stop(100%,#84B23C)) !important;}");
+            var cssResult = css.Rules[0].ToString();
+
+            Assert.That(css.Errors.Count == 0);
+            Assert.AreEqual(@".c{background:-webkit-gradient(linear,left top,left bottom,color-stop(0,#9ACE48),color-stop(100%,#84B23C)) !important;}", cssResult);
         }
     }
 }

--- a/ExCSS/ExCSS.csproj
+++ b/ExCSS/ExCSS.csproj
@@ -79,6 +79,8 @@
     <Compile Include="Model\IStyleDeclaration.cs" />
     <Compile Include="Model\Selector\NthOfTypeSelector.cs" />
     <Compile Include="Model\Selector\NthLastOfTypeSelector.cs" />
+    <Compile Include="Model\Values\Comma.cs" />
+    <Compile Include="Model\Values\Whitespace.cs" />
     <Compile Include="StylesheetParseError.cs" />
     <Compile Include="StyleSheet.cs" />
     <Compile Include="Model\Extensions\CharacterExtensions.cs" />

--- a/ExCSS/Lexer.cs
+++ b/ExCSS/Lexer.cs
@@ -387,7 +387,7 @@ namespace ExCSS
 
         private Block HashStart(char current)
         {
-            if (current.IsNameStart())
+            if (current.IsNameStart() || current.IsDigit())
             {
                 _buffer.Append(current);
                 return HashRest(_stylesheetReader.Next);

--- a/ExCSS/Model/FunctionBuffer.cs
+++ b/ExCSS/Model/FunctionBuffer.cs
@@ -39,7 +39,7 @@ namespace ExCSS.Model
         public Term Done()
         {
             Include();
-            return BuildFunctionTerm(_function, _termList); 
+            return BuildFunctionTerm(_function, _termList);
         }
 
         private Term BuildFunctionTerm(string name, List<Term> terms)
@@ -47,58 +47,58 @@ namespace ExCSS.Model
             switch (name)
             {
                 case "rgb":
-                {
-                    if (terms.Count == 3)
                     {
-                        if (CheckNumber(terms[0]) &&
-                            CheckNumber(terms[1]) && 
-                            CheckNumber(terms[2]))
+                        if (terms.Count == 5)
                         {
-                            return HtmlColor.FromRgb(
-                                ToByte(terms[0]), 
-                                ToByte(terms[1]),
-                                ToByte(terms[2]));
+                            if (CheckNumber(terms[0]) &&
+                                CheckNumber(terms[2]) &&
+                                CheckNumber(terms[4]))
+                            {
+                                return HtmlColor.FromRgb(
+                                    ToByte(terms[0]),
+                                    ToByte(terms[2]),
+                                    ToByte(terms[4]));
+                            }
                         }
-                    }
 
-                    break;
-                }
+                        break;
+                    }
                 case "rgba":
-                {
-                    if (terms.Count == 4)
                     {
-                        if (CheckNumber(terms[0]) && 
-                            CheckNumber(terms[1]) && 
-                            CheckNumber(terms[2]) &&
-                            CheckNumber(terms[3]))
+                        if (terms.Count == 7)
                         {
-                            return HtmlColor.FromRgba(
-                                ToByte(terms[0]), 
-                                ToByte(terms[1]),
-                                ToByte(terms[2]), 
-                                ToSingle(terms[3]));
+                            if (CheckNumber(terms[0]) &&
+                                CheckNumber(terms[2]) &&
+                                CheckNumber(terms[4]) &&
+                                CheckNumber(terms[6]))
+                            {
+                                return HtmlColor.FromRgba(
+                                    ToByte(terms[0]),
+                                    ToByte(terms[2]),
+                                    ToByte(terms[4]),
+                                    ToSingle(terms[6]));
+                            }
                         }
-                    }
 
-                    break;
-                }
+                        break;
+                    }
                 case "hsl":
-                {
-                    if (_termList.Count == 3)
                     {
-                        if (CheckNumber(terms[0]) && 
-                            CheckNumber(terms[1]) && 
-                            CheckNumber(terms[2]))
+                        if (_termList.Count == 5)
                         {
-                            return HtmlColor.FromHsl(
-                                ToSingle(terms[0]), 
-                                ToSingle(terms[1]), 
-                                ToSingle(terms[2]));
+                            if (CheckNumber(terms[0]) &&
+                                CheckNumber(terms[2]) &&
+                                CheckNumber(terms[4]))
+                            {
+                                return HtmlColor.FromHsl(
+                                    ToSingle(terms[0]),
+                                    ToSingle(terms[2]),
+                                    ToSingle(terms[4]));
+                            }
                         }
-                    }
 
-                    break;
-                }
+                        break;
+                    }
             }
 
             return new GenericFunction(name, terms);

--- a/ExCSS/Model/Values/Comma.cs
+++ b/ExCSS/Model/Values/Comma.cs
@@ -1,0 +1,11 @@
+﻿// ReSharper disable once CheckNamespace
+namespace ExCSS
+{
+    public class Comma : Term
+    {
+        public override string ToString()
+        {
+            return ",";
+        }
+    }
+}

--- a/ExCSS/Model/Values/GenericFunction.cs
+++ b/ExCSS/Model/Values/GenericFunction.cs
@@ -10,19 +10,15 @@ namespace ExCSS
         public string Name { get; set; }
         public TermList Arguments { get; set; }
 
-        public GenericFunction(string name, List<Term> arguments)
+        public GenericFunction(string name, IEnumerable<Term> arguments)
         {
-            this.Name = name;
-
+            Name = name;
             var list = new TermList();
-            for (int n = 0; n < arguments.Count; n++)
+            foreach (var term in arguments)
             {
-                list.AddTerm(arguments[n]);
-                if (n == arguments.Count - 1)
-                    break;
-                list.AddSeparator(GrammarSegment.Comma);
+                list.AddTerm(term);
             }
-            this.Arguments = list;
+            Arguments = list;
         }
 
         public override string ToString()

--- a/ExCSS/Model/Values/HtmlColor.cs
+++ b/ExCSS/Model/Values/HtmlColor.cs
@@ -208,7 +208,7 @@ namespace ExCSS
                 //return "rgb(" + R + ", " + G + ", " + B + ")";
             }
 
-            return "rgba(" + R + ", " + G + ", " + B + ", " + Alpha.ToString("0.##") + ")";
+            return "rgba(" + R + "," + G + "," + B + "," + Alpha.ToString("0.##") + ")";
         }
 
         public bool Equals(HtmlColor other)

--- a/ExCSS/Model/Values/TermList.cs
+++ b/ExCSS/Model/Values/TermList.cs
@@ -30,38 +30,11 @@ namespace ExCSS
 
         public void AddTerm(Term term)
         {
-            if (_items.Count != _separator.Count)
-            {
-                throw new NotSupportedException("Must call AddTerm AddSeparator in that order");
-            }
-
             _items.Add(term);
-        }
-
-        public void AddSeparator(TermSeparator termSeparator)
-        {
-            switch(termSeparator)
-            {
-                case(TermSeparator.Comma):
-                {
-                    AddSeparator(GrammarSegment.Comma);
-                    break;
-                }
-	             case(TermSeparator.Space):
-                {
-                    AddSeparator(GrammarSegment.Whitespace);
-                    break;
-                }
-            }
         }
 
         internal void AddSeparator(GrammarSegment termSepertor)
         {
-            if (_items.Count != _separator.Count + 1)
-            {
-                throw new NotSupportedException("Must call AddTerm AddSeparator in that order");
-            }
-
             _separator.Add(termSepertor);
         }
 
@@ -90,8 +63,7 @@ namespace ExCSS
             {
                 builder.Append(_items[i]);
 
-                if (i == _separator.Count)
-                    break;
+                if (_separator.Count - 1 < i) continue;
 
                 switch (_separator[i])
                 {

--- a/ExCSS/Model/Values/Whitespace.cs
+++ b/ExCSS/Model/Values/Whitespace.cs
@@ -1,0 +1,11 @@
+﻿// ReSharper disable once CheckNamespace
+namespace ExCSS
+{
+    public class Whitespace : Term
+    {
+        public override string ToString()
+        {
+            return " ";
+        }
+    }
+}

--- a/ExCSS/Parser.cs
+++ b/ExCSS/Parser.cs
@@ -226,6 +226,7 @@ namespace ExCSS
                 case ParsingContext.InCondition:
                 case ParsingContext.InSingleValue:
                 case ParsingContext.InMediaValue:
+                case ParsingContext.InFunction:
                     _lexer.IgnoreComments = true;
                     _lexer.IgnoreWhitespace = false;
                     break;


### PR DESCRIPTION
Fixed gradient-like functions by treating inner function whitespaces/commas as significant. Fixed color hash parsing. Added unit tests.

https://github.com/TylerBrinks/ExCSS/issues/26
