### PR TITLE
Escape control characters in primitive term string values

### DIFF
--- a/ExCSS.Tests/PropertyFixture.cs
+++ b/ExCSS.Tests/PropertyFixture.cs
@@ -57,5 +57,30 @@ namespace ExCSS.Tests
             var css = parser.Parse(".class{color:hsl(0, 100,50);");
             Assert.AreEqual(".class{color:#F2AAAA;}", css.ToString());
         }
+
+        [Test]
+        public void PrimitiveString_DoubleQuoteAndEscapeControlCharacters()
+        {
+            var parser = new Parser();
+            var css = parser.Parse(@".body:after{content:""\A\273C\A"";}");
+            Assert.AreEqual(@".body:after{content:""\A✼\A"";}", css.ToString());
+        }
+
+        [Test]
+        public void PrimitiveString_SingleQuoteStringsWithoutControlCharacters()
+        {
+            var parser = new Parser();
+            var css = parser.Parse(@".body:after{content:'boo';}");
+            Assert.AreEqual(@".body:after{content:'boo';}", css.ToString());
+        }
+
+        [Test]
+        public void PrimitiveString_EmptyValue()
+        {
+            var parser = new Parser();
+            var css = parser.Parse(@".body:after{content:'';}");
+            Assert.AreEqual(@".body:after{content:'';}", css.ToString());
+        }
+
     }
 }

--- a/ExCSS/Model/Values/PrimitiveTerm.cs
+++ b/ExCSS/Model/Values/PrimitiveTerm.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using System.Globalization;
 
 // ReSharper disable once CheckNamespace
@@ -51,7 +52,7 @@ namespace ExCSS
             switch (PrimitiveType)
             {
                 case UnitType.String:
-                    return "'" + Value + "'";
+                    return EscapedString(Value.ToString());
 
                 case UnitType.Uri:
                     return "url(" + Value + ")";
@@ -62,6 +63,30 @@ namespace ExCSS
 
                     return Value.ToString();
             }
+        }
+
+        internal static string EscapedString(string value)
+        {
+            StringBuilder encoded = new StringBuilder();
+
+            var hasControl = false;
+            foreach (var ch in value)
+            {
+                if (Char.IsControl(ch))
+                {
+                    encoded.AppendFormat("\\{0:X}", Convert.ToInt32(ch));
+                    hasControl = true;
+                }
+                else
+                    encoded.Append(ch);
+
+            }
+
+            char quoted = hasControl ? '\"' : '\'';
+            encoded.Insert(0, quoted);
+            encoded.Append(quoted);
+
+            return encoded.ToString();
         }
 
         internal static UnitType ConvertStringToUnitType(string unit)


### PR DESCRIPTION
Fixes defect in which control characters in primitive term string type values could result in invalid css.  For example:
.body:after{content:"\A\273C\A";}
