### PR TITLE
Allow construction of whitespace-separated termlists + fix unknown at-rules with body like @-ms-viewport

### DIFF
--- a/ExCSS.Tests/AtRuleFixture.cs
+++ b/ExCSS.Tests/AtRuleFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using NUnit.Framework;
 
 namespace ExCSS.Tests
@@ -283,6 +284,33 @@ namespace ExCSS.Tests
             var namespaces = css.NamespaceDirectives;
 
             Assert.AreEqual("@namespace 'http://toto.example.org';", namespaces[0].ToString());
+        }
+        #endregion
+
+
+        #region Unknown directive
+        [Test]
+        public void Parser_Does_Not_Stop_On_Unknown_Directive()
+        {
+            var input = "@custom url(img.jpg);.other{color:red;}";
+            var parser = new Parser();
+            var css = parser.Parse(input);
+
+            Assert.AreEqual(input, css.ToString(false));
+            Assert.AreEqual(2, css.Rules.Count);
+            Assert.AreEqual(1, css.StyleRules.Count);
+        }
+
+        [Test]
+        public void Parser_Does_Not_Stop_On_Unknown_Directive_With_Body()
+        {
+            var input = "@-ms-viewport{width:device-width;}.other{color:red;}";
+            var parser = new Parser();
+            var css = parser.Parse(input);
+
+            Assert.AreEqual(input, css.ToString(false));
+            Assert.AreEqual(2, css.Rules.Count);
+            Assert.AreEqual(1, css.StyleRules.Count);
         }
         #endregion
     }

--- a/ExCSS/Model/Rules/GenericRule.cs
+++ b/ExCSS/Model/Rules/GenericRule.cs
@@ -1,10 +1,24 @@
 ﻿// ReSharper disable once CheckNamespace
+
+using System;
+using System.Linq;
+using System.Text;
+using ExCSS.Model;
+
 namespace ExCSS
 {
-    public class GenericRule : AggregateRule
+    public class GenericRule : AggregateRule, ISupportsDeclarations
     {
         private string _text;
         private bool _stopped;
+
+
+        public StyleDeclaration Declarations { get; private set; }
+
+        public GenericRule()
+        {
+            Declarations = new StyleDeclaration();
+        }
 
         internal void SetInstruction(string text)
         {
@@ -29,8 +43,19 @@ namespace ExCSS
             {
                 return _text + ";";
             }
-
-            return _text + "{" + RuleSets + "}";
+            var sb = new StringBuilder();
+            sb.Append(_text).Append("{");
+            sb.Append(Declarations.ToString(friendlyFormat, indentation));
+            foreach (var rule in  RuleSets)
+            {
+                if (friendlyFormat)
+                    sb.AppendLine();
+                sb.Append(rule.ToString(friendlyFormat, indentation));
+            }
+            if (friendlyFormat)
+                sb.AppendLine();
+            sb.Append("}");
+            return sb.ToString();
         }
     }
 }

--- a/ExCSS/Model/Values/TermList.cs
+++ b/ExCSS/Model/Values/TermList.cs
@@ -11,20 +11,24 @@ namespace ExCSS
     {
         private readonly List<GrammarSegment> _separator = new List<GrammarSegment>();
         private readonly List<Term> _items = new List<Term>();
-        private const GrammarSegment DefaultSeparator = GrammarSegment.Comma;
 
         public TermList()
         {
         }
 
         public TermList(params Term[] terms)
+            : this(TermSeparator.Comma,terms)
         {
-            for(var i = 0; i < terms.Length; ++i)
+        }
+
+        public TermList(TermSeparator separator, params Term[] terms)
+        {
+            for (var i = 0; i < terms.Length; ++i)
             {
                 AddTerm(terms[i]);
-                if(i != terms.Length-1)
+                if (i != terms.Length - 1)
                 {
-                    AddSeparator(DefaultSeparator);
+                    AddSeparator(separator);
                 }
             }
         }
@@ -37,6 +41,24 @@ namespace ExCSS
         internal void AddSeparator(GrammarSegment termSepertor)
         {
             _separator.Add(termSepertor);
+        }
+
+        public void AddSeparator(TermSeparator termSepertor)
+        {
+            switch (termSepertor)
+            {
+                case TermSeparator.Comma:
+                    _separator.Add(GrammarSegment.Comma);
+                    break;
+                case TermSeparator.Space:
+                    _separator.Add(GrammarSegment.Whitespace);
+                    break;
+                case TermSeparator.Colon:
+                    _separator.Add(GrammarSegment.Colon);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException("termSepertor");
+            }
         }
 
         public int Length
@@ -106,7 +128,8 @@ namespace ExCSS
         public enum TermSeparator
         {
             Comma,
-            Space
+            Space,
+            Colon,
         }
     }
 }

--- a/ExCSS/Parser.Blocks.cs
+++ b/ExCSS/Parser.Blocks.cs
@@ -215,7 +215,7 @@ namespace ExCSS
 
                 case GrammarSegment.CurlyBraceOpen:
                     CastRuleSet<GenericRule>().SetCondition(_buffer.ToString());
-                    SetParsingContext(ParsingContext.DataBlock);
+                    SetParsingContext(ParsingContext.InDeclaration);
                     break;
 
                 default:


### PR DESCRIPTION
It's currently impossible to construct expressions like 

         background: url(image.png) no-repeat;

since the default separator of TermList constructor is a comma, and the .AddSeparator method is internal.

This commit fixes it.

