### PR TITLE
Support of 'rem' unit.

### DIFF
--- a/ExCSS/Model/Enumerations.cs
+++ b/ExCSS/Model/Enumerations.cs
@@ -182,6 +182,7 @@ namespace ExCSS
         ViewportMin = 29,
         ViewportMax = 30,
         Turn = 31,
+        RootEms = 32,
     }
 
     public enum DocumentFunction

--- a/ExCSS/Model/Values/PrimitiveTerm.cs
+++ b/ExCSS/Model/Values/PrimitiveTerm.cs
@@ -135,6 +135,8 @@ namespace ExCSS
                     return UnitType.ViewportMin;
                 case "vmax":
                     return UnitType.ViewportMax;
+                case "rem":
+                    return UnitType.RootEms;
             }
 
             return UnitType.Unknown;
@@ -186,6 +188,8 @@ namespace ExCSS
                     return "vmin";
                 case UnitType.ViewportMax:
                     return "vmax";
+                case UnitType.RootEms:
+                    return "rem";
             }
 
             return string.Empty;


### PR DESCRIPTION
Recognizes *rem* unit, which is currently unrecognized:
    
    p  { font-size: 1.2rem; }