### PR TITLE
Fixes NRE when trying to ToString() an empty stylesheet

### DIFF
--- a/ExCSS.Tests/ExCSS.Tests.csproj
+++ b/ExCSS.Tests/ExCSS.Tests.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="StylesheetFixture.cs" />
     <Compile Include="ParserErrorHandlerFixture.cs" />
     <Compile Include="PropertyFixture.cs" />
     <Compile Include="RenderFormatFixture.cs" />

--- a/ExCSS.Tests/StylesheetFixture.cs
+++ b/ExCSS.Tests/StylesheetFixture.cs
@@ -1,0 +1,17 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+namespace ExCSS.Tests
+{
+    [TestFixture]
+    public class StylesheetFixture
+    {
+        [Test]
+        public void Empty_stylesheet_does_not_throw_on_ToString()
+        {
+            var parser = new Parser();
+            var styleSheet = parser.Parse(string.Empty);
+            styleSheet.ToString();
+        }
+    }
+}

--- a/ExCSS/Model/Extensions/StringExtensions.cs
+++ b/ExCSS/Model/Extensions/StringExtensions.cs
@@ -38,9 +38,12 @@ namespace ExCSS.Model.Extensions
 
         public static StringBuilder TrimLastLine(this StringBuilder builder)
         {
-            while (builder[builder.Length-1] == '\r' || builder[builder.Length-1] == '\n' || builder[builder.Length-1] == '\t')
+            if (builder.Length > 0)
             {
-                builder.Remove(builder.Length - 1, 1);
+                while (builder[builder.Length - 1] == '\r' || builder[builder.Length - 1] == '\n' || builder[builder.Length - 1] == '\t')
+                {
+                    builder.Remove(builder.Length - 1, 1);
+                }
             }
 
             return builder;
@@ -48,9 +51,12 @@ namespace ExCSS.Model.Extensions
 
         public static StringBuilder TrimFirstLine(this StringBuilder builder)
         {
-            while (builder[0] == '\r' || builder[0] == '\n' || builder[0] == '\t')
+            if (builder.Length > 0)
             {
-                builder.Remove(0, 1);
+                while (builder[0] == '\r' || builder[0] == '\n' || builder[0] == '\t')
+                {
+                    builder.Remove(0, 1);
+                }
             }
 
             return builder;


### PR DESCRIPTION
I understand that in the wild it's quite unlikely to encounter empty stylesheets. But I ran into this exception when unit-testing something that used ExCSS and didn't yet care about the results of the usage.