### PR TITLE
Fixed TargetFrameworks in csproj file.

### DIFF
--- a/src/ExCSS/ExCSS.csproj
+++ b/src/ExCSS/ExCSS.csproj
@@ -8,7 +8,7 @@
     <Authors>Tyler Brinks</Authors>
     <Description>ExCSS is a CSS 2.1 and CSS 3 parser for .NET. ExCSS makes it easy to read and parse stylesheets into a friendly object model with full LINQ support.</Description>
     <RepositoryUrl>https://github.com/TylerBrinks/ExCSS</RepositoryUrl>
-    <PackageVersion>3.0.0-beta1-20170822</PackageVersion>
+    <PackageVersion>3.0.0-beta1-20171227</PackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/ExCSS/ExCSS.csproj
+++ b/src/ExCSS/ExCSS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1;net462</TargetFramework>
+    <TargetFrameworks>netstandard1.1;net462</TargetFrameworks>
     <AssemblyName>ExCSS</AssemblyName>
     <PackageId>ExCSS</PackageId>
     <Title>ExCSS .NET Stylesheet Parser</Title>

--- a/src/ExCSS/ExCSS.csproj
+++ b/src/ExCSS/ExCSS.csproj
@@ -8,7 +8,7 @@
     <Authors>Tyler Brinks</Authors>
     <Description>ExCSS is a CSS 2.1 and CSS 3 parser for .NET. ExCSS makes it easy to read and parse stylesheets into a friendly object model with full LINQ support.</Description>
     <RepositoryUrl>https://github.com/TylerBrinks/ExCSS</RepositoryUrl>
-    <PackageVersion>3.0.0-beta1-20171227</PackageVersion>
+    <PackageVersion>3.0.0</PackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/ExCSS/Model/Stylesheet.cs
+++ b/src/ExCSS/Model/Stylesheet.cs
@@ -22,6 +22,7 @@ namespace ExCSS
         public IEnumerable<IRule> ImportRules => Rules.Where(r => r is ImportRule);
         public IEnumerable<IRule> NamespaceRules => Rules.Where(r => r is NamespaceRule);
         public IEnumerable<IRule> PageRules => Rules.Where(r => r is PageRule);
+        public IEnumerable<IRule> StyleRules => Rules.Where(r => r is StyleRule);
 
         public IRule Add(RuleType ruleType)
         {

--- a/src/ExCSS/Model/Stylesheet.cs
+++ b/src/ExCSS/Model/Stylesheet.cs
@@ -22,7 +22,7 @@ namespace ExCSS
         public IEnumerable<IRule> ImportRules => Rules.Where(r => r is ImportRule);
         public IEnumerable<IRule> NamespaceRules => Rules.Where(r => r is NamespaceRule);
         public IEnumerable<IRule> PageRules => Rules.Where(r => r is PageRule);
-        public IEnumerable<IStyleRule> StyleRules => Rules.Where(r => r is StyleRule);
+        public IEnumerable<IStyleRule> StyleRules => Rules.OfType<IStyleRule>();
 
         public IRule Add(RuleType ruleType)
         {

--- a/src/ExCSS/Model/Stylesheet.cs
+++ b/src/ExCSS/Model/Stylesheet.cs
@@ -22,7 +22,7 @@ namespace ExCSS
         public IEnumerable<IRule> ImportRules => Rules.Where(r => r is ImportRule);
         public IEnumerable<IRule> NamespaceRules => Rules.Where(r => r is NamespaceRule);
         public IEnumerable<IRule> PageRules => Rules.Where(r => r is PageRule);
-        public IEnumerable<IRule> StyleRules => Rules.Where(r => r is StyleRule);
+        public IEnumerable<IStyleRule> StyleRules => Rules.Where(r => r is StyleRule);
 
         public IRule Add(RuleType ruleType)
         {

--- a/src/ExCSS/Rules/StyleRule.cs
+++ b/src/ExCSS/Rules/StyleRule.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace ExCSS
 {
-    internal sealed class StyleRule : Rule
+    public class StyleRule : Rule, IStyleRule
     {
         internal StyleRule(StylesheetParser parser)
             : base(RuleType.Style, parser)


### PR DESCRIPTION
TargetFrameworks (with an s) should be used since multiple frameworks are specified:
https://docs.microsoft.com/en-us/dotnet/core/tools/csproj

I've tested that with this change I can publish the package to a private Nuget feed hosted by VSTS, and that a netstandard 2 project can consume the package.