### PR TITLE
Fixed: StyleRule didn't implement interface IStyleRule

### DIFF
--- a/src/ExCSS.Tests/ExCSS.Tests.csproj
+++ b/src/ExCSS.Tests/ExCSS.Tests.csproj
@@ -24,4 +24,8 @@
     <Folder Include="Properties\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/src/ExCSS.Tests/PropertyTests/UnknownPropertyTests.cs
+++ b/src/ExCSS.Tests/PropertyTests/UnknownPropertyTests.cs
@@ -1,0 +1,24 @@
+﻿namespace ExCSS.Tests
+{
+    using ExCSS;
+    using Xunit;
+
+    //[TestFixture]
+    public class UnknownPropertyTests : CssConstructionFunctions
+    {
+        [Fact]
+        public void Test()
+        {
+            var snippet = "BackgroundColour: #ff0000;";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("background-attachment", property.Name);
+            Assert.False(property.IsImportant);
+            Assert.IsType<BackgroundAttachmentProperty>(property);
+            var concrete = (BackgroundAttachmentProperty)property;
+            Assert.False(concrete.IsInherited);
+            Assert.True(concrete.HasValue);
+            Assert.Equal("scroll", concrete.Value);
+        }
+
+    }
+}

--- a/src/ExCSS/ExCSS.csproj
+++ b/src/ExCSS/ExCSS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.1;net462</TargetFramework>
+    <TargetFramework>netstandard1.1</TargetFramework>
     <AssemblyName>ExCSS</AssemblyName>
     <PackageId>ExCSS</PackageId>
     <Title>ExCSS .NET Stylesheet Parser</Title>

--- a/src/ExCSS/Model/Combinator.cs
+++ b/src/ExCSS/Model/Combinator.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace ExCSS
 {
-    internal abstract class Combinator
+    public abstract class Combinator
     {
         public virtual ISelector Change(ISelector selector)
         {

--- a/src/ExCSS/Rules/StyleRule.cs
+++ b/src/ExCSS/Rules/StyleRule.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace ExCSS
 {
-    internal sealed class StyleRule : Rule
+    internal sealed class StyleRule : Rule, IStyleRule
     {
         internal StyleRule(StylesheetParser parser)
             : base(RuleType.Style, parser)

--- a/src/ExCSS/Selectors/ChildSelector.cs
+++ b/src/ExCSS/Selectors/ChildSelector.cs
@@ -2,7 +2,7 @@
 
 namespace ExCSS
 {
-    internal abstract class ChildSelector : StylesheetNode, ISelector
+    public abstract class ChildSelector : StylesheetNode, ISelector
     {
         private readonly string _name;
         protected int _step;

--- a/src/ExCSS/Selectors/ComplexSelector.cs
+++ b/src/ExCSS/Selectors/ComplexSelector.cs
@@ -12,7 +12,7 @@ namespace ExCSS
             _selectors = new List<CombinatorSelector>();
         }
 
-        private struct CombinatorSelector
+        public struct CombinatorSelector
         {
             public string Delimiter;
             public ISelector Selector;
@@ -22,6 +22,7 @@ namespace ExCSS
         public string Text => this.ToCss();
         public int Length => _selectors.Count;
         public bool IsReady { get; private set; }
+        public IEnumerable<CombinatorSelector> Selectors => _selectors;
         public Priority Specifity
         {
             get

--- a/src/ExCSS/Selectors/ComplexSelector.cs
+++ b/src/ExCSS/Selectors/ComplexSelector.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace ExCSS
 {
-    internal sealed class ComplexSelector : StylesheetNode, ISelector
+    public sealed class ComplexSelector : StylesheetNode, ISelector
     {
         private readonly List<CombinatorSelector> _selectors;
 

--- a/src/ExCSS/Selectors/CompoundSelector.cs
+++ b/src/ExCSS/Selectors/CompoundSelector.cs
@@ -2,7 +2,7 @@
 
 namespace ExCSS
 {
-    internal sealed class CompoundSelector : Selectors, ISelector
+    public sealed class CompoundSelector : Selectors, ISelector
     {
         public override void ToCss(TextWriter writer, IStyleFormatter formatter)
         {

--- a/src/ExCSS/Selectors/FirstChildSelector.cs
+++ b/src/ExCSS/Selectors/FirstChildSelector.cs
@@ -1,7 +1,7 @@
 ﻿namespace ExCSS
 
 {
-    internal sealed class FirstChildSelector : ChildSelector
+    public sealed class FirstChildSelector : ChildSelector
     {
         public FirstChildSelector()
             : base(PseudoClassNames.NthChild)

--- a/src/ExCSS/Selectors/FirstColumnSelector.cs
+++ b/src/ExCSS/Selectors/FirstColumnSelector.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace ExCSS
 {
-    internal sealed class FirstColumnSelector : ChildSelector
+    public sealed class FirstColumnSelector : ChildSelector
     {
         public FirstColumnSelector()
             : base(PseudoClassNames.NthColumn)

--- a/src/ExCSS/Selectors/FirstTypeSelector.cs
+++ b/src/ExCSS/Selectors/FirstTypeSelector.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace ExCSS
 {
-    internal sealed class FirstTypeSelector : ChildSelector
+    public sealed class FirstTypeSelector : ChildSelector
     {
         public FirstTypeSelector()
             : base(PseudoClassNames.NthOfType)

--- a/src/ExCSS/Selectors/LastChildSelector.cs
+++ b/src/ExCSS/Selectors/LastChildSelector.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace ExCSS
 {
-    internal sealed class LastChildSelector : ChildSelector
+    public sealed class LastChildSelector : ChildSelector
     {
         public LastChildSelector()
             : base(PseudoClassNames.NthLastChild)

--- a/src/ExCSS/Selectors/LastColumnSelector.cs
+++ b/src/ExCSS/Selectors/LastColumnSelector.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace ExCSS
 {
-    internal sealed class LastColumnSelector : ChildSelector
+    public sealed class LastColumnSelector : ChildSelector
     {
         public LastColumnSelector()
             : base(PseudoClassNames.NthLastColumn)

--- a/src/ExCSS/Selectors/LastTypeSelector.cs
+++ b/src/ExCSS/Selectors/LastTypeSelector.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace ExCSS
 {
-    internal sealed class LastTypeSelector : ChildSelector
+    public sealed class LastTypeSelector : ChildSelector
     {
         public LastTypeSelector()
             : base(PseudoClassNames.NthLastOfType)

--- a/src/ExCSS/Selectors/ListSelector.cs
+++ b/src/ExCSS/Selectors/ListSelector.cs
@@ -2,7 +2,7 @@
 
 namespace ExCSS
 {
-    internal sealed class ListSelector : Selectors, ISelector
+    public sealed class ListSelector : Selectors, ISelector
     {
         public bool IsInvalid { get; internal set; }
 

--- a/src/ExCSS/Selectors/Selectors.cs
+++ b/src/ExCSS/Selectors/Selectors.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace ExCSS
 {
-    internal abstract class Selectors : StylesheetNode, IEnumerable<ISelector>
+    public abstract class Selectors : StylesheetNode, IEnumerable<ISelector>
     {
         protected readonly List<ISelector> _selectors;
 

--- a/src/ExCSS/Selectors/SimpleSelector.cs
+++ b/src/ExCSS/Selectors/SimpleSelector.cs
@@ -2,7 +2,7 @@
 
 namespace ExCSS
 {
-    internal sealed class SimpleSelector : StylesheetNode, ISelector
+    public sealed class SimpleSelector : StylesheetNode, ISelector
     {
         public SimpleSelector() : this(Priority.Zero, Keywords.Asterisk)
         {

--- a/src/ExCSS/Selectors/UnknownSelector.cs
+++ b/src/ExCSS/Selectors/UnknownSelector.cs
@@ -2,7 +2,7 @@
 
 namespace ExCSS
 {
-    internal sealed class UnknownSelector : StylesheetNode, ISelector
+    public sealed class UnknownSelector : StylesheetNode, ISelector
     {
         public Priority Specifity => Priority.Zero;
 


### PR DESCRIPTION
IStyleRule wasn't implemented by StyleRule which meant there was no way to reference the properties of this class outside the library