### PR TITLE
ICharsetRule and IImportRule inherit from IRule.

### DIFF
--- a/src/ExCSS/Rules/ICharsetRule.cs
+++ b/src/ExCSS/Rules/ICharsetRule.cs
@@ -1,6 +1,6 @@
 ﻿namespace ExCSS
 {
-    public interface ICharsetRule
+    public interface ICharsetRule : IRule
     {
         string CharacterSet { get; set; }
     }

--- a/src/ExCSS/Rules/IImportRule.cs
+++ b/src/ExCSS/Rules/IImportRule.cs
@@ -1,6 +1,6 @@
 ﻿namespace ExCSS
 {
-    public interface IImportRule
+    public interface IImportRule : IRule
     {
         string Href { get; set; }
         MediaList Media { get; }


### PR DESCRIPTION
Backward compatibility is no longer maintained due to 139b66e84a69786ba195d4aa8fedc3235a66a588.
We believe that all Rule interfaces must inherit from IRule.