### PR TITLE
Allow preserving duplicate properties in a style declaration

### DIFF
--- a/src/ExCSS.Tests/ConstructionFunctions.cs
+++ b/src/ExCSS.Tests/ConstructionFunctions.cs
@@ -10,7 +10,8 @@
              bool tolerateInvalidSelectors = false,
              bool tolerateInvalidValues = false,
              bool tolerateInvalidConstraints = false,
-             bool preserveComments = false)
+             bool preserveComments = false,
+             bool preserveDuplicateProperties = false)
         {
             var parser = new StylesheetParser(
                 includeUnknownRules,
@@ -18,7 +19,8 @@
                 tolerateInvalidSelectors,
                 tolerateInvalidValues,
                 tolerateInvalidConstraints,
-                preserveComments);
+                preserveComments,
+                preserveDuplicateProperties);
 
             return parser.Parse(source);
         }

--- a/src/ExCSS.Tests/Sheet.cs
+++ b/src/ExCSS.Tests/Sheet.cs
@@ -1191,5 +1191,24 @@ font-weight:bold;}";
             Assert.NotNull(hwbAlpha);
             Assert.NotNull(hwbAngleAlpha);
         }
+
+        [Fact]
+        public void ShouldBeAbleToPreserveDuplicateProperties()
+        {
+            var sheet = ParseStyleSheet(@"
+h1 {
+ color: red;
+ color: some-invalid-color;",
+            tolerateInvalidValues: true,
+            preserveDuplicateProperties: true);
+            Assert.Equal(1, sheet.Rules.Length);
+            Assert.IsType<StyleRule>(sheet.Rules[0]);
+            var h1 = sheet.Rules[0] as StyleRule;
+            Assert.Equal("h1", h1.SelectorText);
+            var props = h1.Style.Children.OfType<Property>().ToList();
+            Assert.Equal("red", props[0].Value);
+            Assert.Equal("some-invalid-color", props[1].Value);
+        }
+
     }
 }

--- a/src/ExCSS/Model/ParserOptions.cs
+++ b/src/ExCSS/Model/ParserOptions.cs
@@ -8,5 +8,6 @@
         public bool AllowInvalidValues { get; set; }
         public bool AllowInvalidConstraints { get; set; }
         public bool PreserveComments { get; set; }
+        public bool PreserveDuplicateProperties { get; set; }
     }
 }

--- a/src/ExCSS/Model/StyleDeclaration.cs
+++ b/src/ExCSS/Model/StyleDeclaration.cs
@@ -337,6 +337,7 @@ namespace ExCSS
                     break;
                 }
             }
+            AppendChild(property);
         }
 
         private void SetShorthand(ShorthandProperty shorthand)

--- a/src/ExCSS/Model/StyleDeclaration.cs
+++ b/src/ExCSS/Model/StyleDeclaration.cs
@@ -328,13 +328,15 @@ namespace ExCSS
 
         void SetLonghand(Property property)
         {
-            foreach (var declaration in Declarations)
+            if (!_parser.Options.PreserveDuplicateProperties)
             {
-                if (!declaration.Name.Is(property.Name)) { continue;}
-                RemoveChild(declaration);
-                break;
+                foreach (var declaration in Declarations)
+                {
+                    if (!declaration.Name.Is(property.Name)) { continue; }
+                    RemoveChild(declaration);
+                    break;
+                }
             }
-            AppendChild(property);
         }
 
         private void SetShorthand(ShorthandProperty shorthand)

--- a/src/ExCSS/Parser/StylesheetParser.cs
+++ b/src/ExCSS/Parser/StylesheetParser.cs
@@ -17,8 +17,9 @@ namespace ExCSS
              bool tolerateInvalidSelectors = false,
              bool tolerateInvalidValues = false,
              bool tolerateInvalidConstraints = false,
-             bool preserveComments = false
-            ) 
+             bool preserveComments = false,
+             bool preserveDuplicateProperties = false
+            )
         {
             Options = new ParserOptions
             {
@@ -27,7 +28,8 @@ namespace ExCSS
                 AllowInvalidSelectors = tolerateInvalidSelectors,
                 AllowInvalidValues = tolerateInvalidValues,
                 AllowInvalidConstraints = tolerateInvalidConstraints,
-                PreserveComments = preserveComments
+                PreserveComments = preserveComments,
+                PreserveDuplicateProperties = preserveDuplicateProperties,
             };
         }
 


### PR DESCRIPTION
When preserving invalid values, I want to keep the old values in the style declaration. Because, in case the latest value is wrong, I can fallback to the old value.

So I added a new option. I believe this is completely backwards compatible.