### PR TITLE
Add .NET Standard 2.0 as target framework.

### DIFF
--- a/src/ExCSS/ExCSS.csproj
+++ b/src/ExCSS/ExCSS.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<LangVersion>9.0</LangVersion>
-		<TargetFrameworks>net5.0;netcoreapp3.1;net452</TargetFrameworks>
+		<TargetFrameworks>net5.0;netstandard2.0;netcoreapp3.1;net452</TargetFrameworks>
 		<AssemblyName>ExCSS</AssemblyName>
 		<PackageId>ExCSS</PackageId>
 		<Title>ExCSS .NET Stylesheet Parser</Title>


### PR DESCRIPTION
Please do not remove `.NET Standard` from target frameworks yet.