### PR TITLE
Add Original property in IProperty.

### DIFF
--- a/src/ExCSS.Tests/Property.cs
+++ b/src/ExCSS.Tests/Property.cs
@@ -17,6 +17,7 @@
             var concrete = (BreakAfterProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("avoid", concrete.Value);
+            Assert.Equal("avoid", concrete.Original);
         }
 
         [Fact]
@@ -31,6 +32,7 @@
             var concrete = (PageBreakAfterProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("avoid", concrete.Value);
+            Assert.Equal("avoid", concrete.Original);
         }
 
         [Fact]
@@ -45,6 +47,7 @@
             var concrete = (BreakAfterProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("page", concrete.Value);
+            Assert.Equal("Page", concrete.Original);
         }
 
         [Fact]
@@ -72,6 +75,7 @@
             var concrete = (BreakAfterProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("avoid-column", concrete.Value);
+            Assert.Equal("avoid-column", concrete.Original);
         }
 
         [Fact]
@@ -86,6 +90,7 @@
             var concrete = (BreakBeforeProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("auto", concrete.Value);
+            Assert.Equal("AUTO", concrete.Original);
         }
 
         [Fact]
@@ -100,6 +105,7 @@
             var concrete = (PageBreakBeforeProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("auto", concrete.Value);
+            Assert.Equal("AUTO", concrete.Original);
         }
 
         [Fact]
@@ -114,6 +120,7 @@
             var concrete = (PageBreakBeforeProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("left", concrete.Value);
+            Assert.Equal("left", concrete.Original);
         }
 
         [Fact]
@@ -154,6 +161,7 @@
             var concrete = (BreakInsideProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("avoid-region", concrete.Value);
+            Assert.Equal("avoid-REGION", concrete.Original);
         }
 
         [Fact]
@@ -168,6 +176,7 @@
             var concrete = (PageBreakInsideProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("avoid", concrete.Value);
+            Assert.Equal("avoid", concrete.Original);
         }
 
         [Fact]
@@ -182,6 +191,7 @@
             var concrete = (PageBreakInsideProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("auto", concrete.Value);
+            Assert.Equal("AUTO", concrete.Original);
         }
 
         [Fact]
@@ -196,6 +206,7 @@
             var concrete = (ClearProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("left", concrete.Value);
+            Assert.Equal("left", concrete.Original);
         }
 
         [Fact]
@@ -210,6 +221,7 @@
             var concrete = (ClearProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("both", concrete.Value);
+            Assert.Equal("both", concrete.Original);
         }
 
         [Fact]
@@ -251,6 +263,7 @@
             var concrete = (PositionProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("absolute", concrete.Value);
+            Assert.Equal("absolute", concrete.Original);
         }
 
         [Fact]
@@ -265,6 +278,7 @@
             var concrete = (DisplayProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("block", concrete.Value);
+            Assert.Equal("block", concrete.Original);
         }
 
         [Fact]
@@ -279,6 +293,7 @@
             var concrete = (VisibilityProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("collapse", concrete.Value);
+            Assert.Equal("collapse", concrete.Original);
         }
 
         [Fact]
@@ -293,6 +308,7 @@
             var concrete = (VisibilityProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("hidden", concrete.Value);
+            Assert.Equal("HIDDEN", concrete.Original);
         }
 
         [Fact]
@@ -307,6 +323,7 @@
             var concrete = (OverflowProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("auto", concrete.Value);
+            Assert.Equal("auto", concrete.Original);
         }
 
         [Fact]
@@ -321,6 +338,7 @@
             var concrete = (TableLayoutProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.Equal("fixed", concrete.Value);
+            Assert.Equal("fiXed", concrete.Original);
         }
 
         [Fact]
@@ -335,6 +353,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("5px 4px", concrete.Value);
+            Assert.Equal("5px 4px", concrete.Original);
         }
 
         [Fact]
@@ -349,6 +368,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("inset 5px 4px", concrete.Value);
+            Assert.Equal("inset 5px 4px", concrete.Original);
         }
 
         [Fact]
@@ -363,6 +383,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("none", concrete.Value);
+            Assert.Equal("NONE", concrete.Original);
         }
 
         [Fact]
@@ -377,6 +398,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("60px -16px rgb(0, 128, 128)", concrete.Value);
+            Assert.Equal("60px -16px teal", concrete.Original);
         }
 
         [Fact]
@@ -391,6 +413,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("10px 5px 5px rgb(0, 0, 0)", concrete.Value);
+            Assert.Equal("10px 5px 5px black", concrete.Original);
         }
 
         [Fact]
@@ -405,6 +428,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("3px 3px rgb(255, 0, 0), -1em 0 0.4em rgb(128, 128, 0)", concrete.Value);
+            Assert.Equal("3px 3px red, -1em 0 0.4em olive", concrete.Original);
         }
 
         [Fact]
@@ -419,6 +443,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("inset 5em 1em rgb(255, 215, 0)", concrete.Value);
+            Assert.Equal("inset 5em 1em gold", concrete.Original);
         }
 
         [Fact]
@@ -433,6 +458,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("0 0 1em rgb(255, 215, 0)", concrete.Value);
+            Assert.Equal("0 0 1em gold", concrete.Original);
         }
 
         [Fact]
@@ -447,6 +473,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("inset 0 0 1em rgb(255, 215, 0)", concrete.Value);
+            Assert.Equal("inset 0 0 1em gold", concrete.Original);
         }
 
         [Fact]
@@ -461,6 +488,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("inset 0 0 1em rgb(255, 215, 0), 0 0 1em rgb(255, 0, 0)", concrete.Value);
+            Assert.Equal("inset 0 0 1em gold, 0 0 1em red", concrete.Original);
         }
 
         [Fact]
@@ -475,6 +503,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("5px 4px rgb(0, 0, 0)", concrete.Value);
+            Assert.Equal("5px 4px #000", concrete.Original);
         }
 
         [Fact]
@@ -489,6 +518,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("5px 4px 2px rgb(0, 0, 0)", concrete.Value);
+            Assert.Equal("5px 4px 2px #000", concrete.Original);
         }
 
         [Fact]
@@ -503,6 +533,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("initial", concrete.Value);
+            Assert.Equal("INITIAL", concrete.Original);
         }
 
         [Fact]
@@ -530,6 +561,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("rect(2px, 3em, 1in, 0)", concrete.Value);
+            Assert.Equal("rect( 2px, 3em, 1in, 0cm )", concrete.Original);
         }
 
         [Fact]
@@ -544,6 +576,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("rect(2px 3em 1in 0)", concrete.Value);
+            Assert.Equal("rect( 2px 3em 1in 0cm )", concrete.Original);
         }
 
         [Fact]
@@ -558,6 +591,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("rect(0, 0, 0, 0)", concrete.Value);
+            Assert.Equal("rect(0, 0, 0, 0)", concrete.Original);
         }
 
         [Fact]
@@ -611,6 +645,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("default", concrete.Value);
+            Assert.Equal("DEFAULT", concrete.Original);
         }
 
         [Fact]
@@ -625,6 +660,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("auto", concrete.Value);
+            Assert.Equal("auto", concrete.Original);
         }
 
         [Fact]
@@ -639,6 +675,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("zoom-out", concrete.Value);
+            Assert.Equal("zoom-out", concrete.Original);
         }
 
         [Fact]
@@ -666,6 +703,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("url(\"foo.png\"), default", concrete.Value);
+            Assert.Equal("url(\"foo.png\"), default", concrete.Original);
         }
 
         [Fact]
@@ -680,6 +718,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("url(\"foo.png\") 0 5, auto", concrete.Value);
+            Assert.Equal("url(\"foo.png\") 0 5, auto", concrete.Original);
         }
 
         [Fact]
@@ -707,6 +746,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("url(\"foo.png\"), url(\"master.png\"), url(\"more.png\"), wait", concrete.Value);
+            Assert.Equal("url(\"foo.png\"), url(\"master.png\"), url(\"more.png\"), wait", concrete.Original);
         }
 
         [Fact]
@@ -721,6 +761,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("rgb(18, 52, 86)", concrete.Value);
+            Assert.Equal("#123456", concrete.Original);
         }
 
         [Fact]
@@ -735,6 +776,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("rgb(121, 181, 201)", concrete.Value);
+            Assert.Equal("rgb(121, 181, 201)", concrete.Original);
         }
 
         [Fact]
@@ -749,6 +791,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("rgba(255, 255, 201, 0.7)", concrete.Value);
+            Assert.Equal("rgba(255, 255, 201, 0.7)", concrete.Original);
         }
 
         [Fact]
@@ -763,6 +806,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("rgb(255, 0, 0)", concrete.Value);
+            Assert.Equal("red", concrete.Original);
         }
 
         [Fact]
@@ -777,6 +821,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("rgb(0, 0, 255)", concrete.Value);
+            Assert.Equal("BLUE", concrete.Original);
         }
 
         [Fact]
@@ -804,6 +849,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("0", concrete.Value);
+            Assert.Equal("0", concrete.Original);
         }
 
         [Fact]
@@ -818,6 +864,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("2", concrete.Value);
+            Assert.Equal("2", concrete.Original);
         }
 
         [Fact]
@@ -871,6 +918,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("slice", concrete.Value);
+            Assert.Equal("slice", concrete.Original);
         }
 
         [Fact]
@@ -885,6 +933,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("clone", concrete.Value);
+            Assert.Equal("Clone", concrete.Original);
         }
 
         [Fact]
@@ -899,6 +948,7 @@
             Assert.True(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("inherit", concrete.Value);
+            Assert.Equal("inherit", concrete.Original);
         }
 
         [Fact]
@@ -913,6 +963,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("normal", concrete.Value);
+            Assert.Equal("normal", concrete.Original);
         }
 
         [Fact]
@@ -927,6 +978,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("none", concrete.Value);
+            Assert.Equal("noNe", concrete.Original);
         }
 
         [Fact]
@@ -941,6 +993,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("\"hi\"", concrete.Value);
+            Assert.Equal("\"hi\"", concrete.Original);
         }
 
         [Fact]
@@ -955,6 +1008,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("no-open-quote no-close-quote", concrete.Value);
+            Assert.Equal("no-open-quote no-close-quote", concrete.Original);
         }
 
         [Fact]
@@ -969,6 +1023,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("url(\"test.html\")", concrete.Value);
+            Assert.Equal("url(\"test.html\")", concrete.Original);
         }
 
         [Fact]
@@ -983,6 +1038,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("\"how\" \"are\" \"you\"", concrete.Value);
+            Assert.Equal("\"how\" \"are\" \"you\"", concrete.Original);
         }
 
         [Fact]
@@ -1010,6 +1066,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("\"\\\"\" \"\\\"\"", concrete.Value);
+            Assert.Equal("\"\\\"\" \"\\\"\"", concrete.Original);
         }
 
         [Fact]
@@ -1037,6 +1094,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("\"\\\"\" \"\\\"\" \"`\" \"´\"", concrete.Value);
+            Assert.Equal("\"\\\"\" \"\\\"\" \"`\" \"´\"", concrete.Original);
         }
 
         [Fact]
@@ -1064,6 +1122,7 @@
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
             Assert.Equal("none", concrete.Value);
+            Assert.Equal("none", concrete.Original);
         }
 
         [Fact]
@@ -1105,6 +1164,7 @@
             Assert.True(concrete.HasValue);
             //Assert.Equal(0, concrete.Count);
             Assert.Equal("0", concrete.Value);
+            Assert.Equal("0", concrete.Original);
         }
 
         [Fact]
@@ -1120,6 +1180,7 @@
             Assert.True(concrete.HasValue);
             //Assert.Equal(3, concrete.Count);
             Assert.Equal("3", concrete.Value);
+            Assert.Equal("3", concrete.Original);
         }
 
         [Fact]
@@ -1149,6 +1210,7 @@
             Assert.True(concrete.HasValue);
             //Assert.Equal(UnicodeMode.Embed, concrete.State);
             Assert.Equal("embed", concrete.Value);
+            Assert.Equal("Embed", concrete.Original);
         }
 
         [Fact]
@@ -1164,6 +1226,7 @@
             Assert.True(concrete.HasValue);
             //Assert.Equal(UnicodeMode.Isolate, concrete.State);
             Assert.Equal("isolate", concrete.Value);
+            Assert.Equal("isolate", concrete.Original);
         }
 
         [Fact]
@@ -1179,6 +1242,7 @@
             Assert.True(concrete.HasValue);
             //Assert.Equal(UnicodeMode.BidiOverride, concrete.State);
             Assert.Equal("bidi-override", concrete.Value);
+            Assert.Equal("Bidi-Override", concrete.Original);
         }
 
         [Fact]
@@ -1194,6 +1258,7 @@
             Assert.True(concrete.HasValue);
             //Assert.Equal(UnicodeMode.Plaintext, concrete.State);
             Assert.Equal("plaintext", concrete.Value);
+            Assert.Equal("PLAINTEXT", concrete.Original);
         }
 
         [Fact]

--- a/src/ExCSS/StyleProperties/IProperty.cs
+++ b/src/ExCSS/StyleProperties/IProperty.cs
@@ -4,6 +4,7 @@
     {
         string Name { get; }
         string Value { get; }
+        string Original { get; }
         bool IsImportant { get; }
     }
 }

--- a/src/ExCSS/StyleProperties/Property.cs
+++ b/src/ExCSS/StyleProperties/Property.cs
@@ -31,6 +31,8 @@ namespace ExCSS
 
         public string Value => DeclaredValue != null ? DeclaredValue.CssText : Keywords.Initial;
 
+        public string Original => DeclaredValue != null ? DeclaredValue.Original.Text : Keywords.Initial;
+
         public bool IsInherited => (_flags & PropertyFlags.Inherited) == PropertyFlags.Inherited && IsInitial ||
                                    DeclaredValue != null && DeclaredValue.CssText.Is(Keywords.Inherit);
 


### PR DESCRIPTION
We may want to use it in the original representation, such as color values(`red`, `black`, etc.), so I add property to `IProperty` to get original value.