### PR TITLE
Add in support for "box-sizing" property

### DIFF
--- a/src/ExCSS.Tests/PropertyTests/BoxSizingPropertyTests.cs
+++ b/src/ExCSS.Tests/PropertyTests/BoxSizingPropertyTests.cs
@@ -1,0 +1,35 @@
+﻿using Xunit;
+
+namespace ExCSS.Tests.PropertyTests
+{
+    public class BoxSizingPropertyTests : CssConstructionFunctions
+    {
+        [Fact]
+        public void BoxSizingContentBoxLegal()
+        {
+            var snippet = "box-sizing: content-box";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("box-sizing", property.Name);
+            Assert.False(property.IsImportant);
+            Assert.IsType<BoxSizingProperty>(property);
+            var concrete = (BoxSizingProperty)property;
+            Assert.False(concrete.IsInherited);
+            Assert.True(concrete.HasValue);
+            Assert.Equal("content-box", concrete.Value);
+        }
+
+        [Fact]
+        public void BoxSizingBorderBoxLegal()
+        {
+            var snippet = "box-sizing: border-box";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("box-sizing", property.Name);
+            Assert.False(property.IsImportant);
+            Assert.IsType<BoxSizingProperty>(property);
+            var concrete = (BoxSizingProperty)property;
+            Assert.False(concrete.IsInherited);
+            Assert.True(concrete.HasValue);
+            Assert.Equal("border-box", concrete.Value);
+        }
+    }
+}

--- a/src/ExCSS/Factories/PropertyFactory.cs
+++ b/src/ExCSS/Factories/PropertyFactory.cs
@@ -58,6 +58,7 @@ namespace ExCSS
 
             AddLonghand(PropertyNames.BorderSpacing, () => new BorderSpacingProperty());
             AddLonghand(PropertyNames.BorderCollapse, () => new BorderCollapseProperty());
+            AddLonghand(PropertyNames.BoxSizing, () => new BoxSizingProperty());
             AddLonghand(PropertyNames.BoxShadow, () => new BoxShadowProperty(), true);
             AddLonghand(PropertyNames.BoxDecorationBreak, () => new BoxDecorationBreak());
             AddLonghand(PropertyNames.BreakAfter, () => new BreakAfterProperty());

--- a/src/ExCSS/Model/Converters.cs
+++ b/src/ExCSS/Model/Converters.cs
@@ -373,6 +373,7 @@ namespace ExCSS
         public static readonly IValueConverter BoxDecorationConverter = Toggle(Keywords.Clone, Keywords.Slice);
         public static readonly IValueConverter ColumnSpanConverter = Toggle(Keywords.All, Keywords.None);
         public static readonly IValueConverter ColumnFillConverter = Toggle(Keywords.Balance, Keywords.Auto);
+        public static readonly IValueConverter BoxSizingConverter = Toggle(Keywords.ContentBox, Keywords.BorderBox);
 
         #endregion
 

--- a/src/ExCSS/StyleProperties/Box/BoxSizingProperty.cs
+++ b/src/ExCSS/StyleProperties/Box/BoxSizingProperty.cs
@@ -1,0 +1,13 @@
+﻿namespace ExCSS
+{
+    internal class BoxSizingProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = Converters.BoxSizingConverter.OrDefault(Keywords.ContentBox);
+
+        public BoxSizingProperty() 
+            : base(PropertyNames.BoxSizing, PropertyFlags.None)
+        { }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}


### PR DESCRIPTION
Support for the box-sizing property was missing, resulting in nothing being present in the parsed stylesheet object model when fed CSS which was setting this.

For example, parsing something like ".test { box-sizing: border-box; }" would result in the parsed stylesheet's stylesheet text showing ".test { }".