### PR TITLE
Fix UnknownProperty being used for known properties

### DIFF
--- a/src/ExCSS.Tests/Cases.cs
+++ b/src/ExCSS.Tests/Cases.cs
@@ -1013,5 +1013,14 @@ lack; }");
             Assert.IsType<Comment>(comment);
             Assert.Equal(" Comment at the start ", ((Comment)comment).Data);
         }
+
+        [Fact]
+        public void StylesheetIncludeUnknownDeclarationsWithKnownPropertyShouldNotUseUnknownProperty()
+        {
+            var parser = new StylesheetParser(includeUnknownDeclarations: true);
+            var document = parser.Parse(@"body { border-width: 0; }");
+
+            Assert.IsNotType<UnknownProperty>(((StyleRule)document.Rules[0]).Style.Children.First());
+        }
     }
 }

--- a/src/ExCSS/Parser/StylesheetComposer.cs
+++ b/src/ExCSS/Parser/StylesheetComposer.cs
@@ -620,10 +620,13 @@ namespace ExCSS
 
             if (propertyName.Length > 0)
             {
-                property = _parser.Options.IncludeUnknownDeclarations ||
-                           _parser.Options.AllowInvalidValues
-                    ? new UnknownProperty(propertyName)
-                    : createProperty(propertyName);
+                property = createProperty(propertyName);
+
+                if (property == null
+                    && (_parser.Options.IncludeUnknownDeclarations || _parser.Options.AllowInvalidValues))
+                {
+                    property = new UnknownProperty(propertyName);
+                }
 
                 if (property == null)
                     RaiseErrorOccurred(ParseError.UnknownDeclarationName, start);


### PR DESCRIPTION
If the parser options `IncludeUnknownDeclarations` or `AllowInvalidValues` are set to `true`, `StylesheetComposer` will incorrectly use `UnknownProperty` for everything, even when the property name in question is a known one.

Fixed by first trying to create the property with the specified name and only falling back to `UnknownProperty` if the created property is null and one of `IncludeUnknownDeclarations`  or `AllowInvalidValues` are set.

The new test case is an example of something that was failing without this fix - despite `border-width` being a known property name, the parsed output would have this as an `UnknownProperty` in the child list.