### PR TITLE
Fix busted tests due to a bug in PeriodicValueConverter from Flexbox changes

### DIFF
--- a/src/ExCSS/ValueConverters/PeriodicValueConverter.cs
+++ b/src/ExCSS/ValueConverters/PeriodicValueConverter.cs
@@ -11,7 +11,7 @@ namespace ExCSS
 
         public PeriodicValueConverter(IValueConverter converter, string[] labels)
         {
-            Debug.Assert(labels.Length == 4 || labels.Length == 2);
+            Debug.Assert(labels.Length == 0 || labels.Length == 4 || labels.Length == 2);
 
             _converter = converter;
             _labels = labels;
@@ -20,7 +20,7 @@ namespace ExCSS
         public IPropertyValue Convert(IEnumerable<Token> value)
         {
             var list = new List<Token>(value);
-            var options = new IPropertyValue[_labels.Length];
+            var options = new IPropertyValue[_labels.Length == 0 ? 4 : _labels.Length];
 
             if (list.Count == 0) return null;
 
@@ -53,11 +53,11 @@ namespace ExCSS
 
             public PeriodicValue(IPropertyValue[] options, IEnumerable<Token> tokens, string[] labels)
             {
-                Debug.Assert(labels.Length == 2 || labels.Length == 4);
+                Debug.Assert(labels.Length == 0 || labels.Length == 2 || labels.Length == 4);
 
-                _values = new IPropertyValue[labels.Length];
+                _values = new IPropertyValue[labels.Length == 0 ? 4 : labels.Length];
 
-                if (labels.Length == 4)
+                if (_values.Length == 0 || _values.Length == 4)
                 {
                     //Top, right, bottom, left
                     _values[0] = options[0];
@@ -79,7 +79,7 @@ namespace ExCSS
             {
                 get
                 {
-                    if (_values.Length == 4)
+                    if (_values.Length == 0 || _values.Length == 4)
                     {
                         var top = _values[0].CssText;
                         var right = _values[1].CssText;


### PR DESCRIPTION
The flexbox PR changed PeriodicValueConverter to work with 2 values instead of only 4, but what was missed was some places were using just `.Periodic()` without any labels specified which triggered the debug assertion on the label count being 2 or 4. 

Because all the value converter stuff is static, the exception raised during the static constructor crashed the XUnit test runner process and hid the fact these tests were failing because they were never actually being run.

This fixes this by treating the case of no labels the same as 4 for backwards compatibility. Confirmed that all tests are now passing with none marked as being skipped.