### PR TITLE
Couple of colour parsing fixes/tweaks

### DIFF
--- a/src/ExCSS.Tests/PropertyTests/BackgroundProperty.cs
+++ b/src/ExCSS.Tests/PropertyTests/BackgroundProperty.cs
@@ -144,10 +144,17 @@
             Assert.Equal("rgb(0, 128, 128)", concrete.Value);
         }
 
-        [Fact]
-        public void BackgroundColorRgbLegal()
+        [Theory]
+        [InlineData("background-color: rgb(255, 255, 128)", "rgb(255, 255, 128)")]
+        [InlineData("background-color: hsla(50, 33%, 25%, 0.75)", "hsla(50deg, 33%, 25%, 0.75)")]
+        [InlineData("background-color : rgb(255  ,  255  ,  128)", "rgb(255, 255, 128)")]
+        [InlineData("background-color: Transparent", "rgba(0, 0, 0, 0)")]
+        [InlineData("background-color: #F09", "rgb(255, 0, 153)")]
+        [InlineData("background-color: #F09F", "rgb(255, 0, 153)")]
+        [InlineData("background-color: #AABBCC", "rgb(170, 187, 204)")]
+        [InlineData("background-color: #AABBCC11", "rgba(170, 187, 204, 0.07)")]
+        public void BackgroundColorRgbLegal(string snippet, string expectedValue)
         {
-            var snippet = "background-color : rgb(255  ,  255  ,  128)";
             var property = ParseDeclaration(snippet);
             Assert.Equal("background-color", property.Name);
             Assert.False(property.IsImportant);
@@ -155,49 +162,7 @@
             var concrete = (BackgroundColorProperty)property;
             Assert.False(concrete.IsInherited);
             Assert.True(concrete.HasValue);
-            Assert.Equal("rgb(255, 255, 128)", concrete.Value);
-        }
-
-        [Fact]
-        public void BackgroundColorHslaLegal()
-        {
-            var snippet = "background-color : hsla(50, 33%, 25%, 0.75)";//equal to rgba(85, 78, 43, 0.75)
-            var property = ParseDeclaration(snippet);
-            Assert.Equal("background-color", property.Name);
-            Assert.False(property.IsImportant);
-            Assert.IsType<BackgroundColorProperty>(property);
-            var concrete = (BackgroundColorProperty)property;
-            Assert.False(concrete.IsInherited);
-            Assert.True(concrete.HasValue);
-            Assert.Equal("hsla(50deg, 33%, 25%, 0.75)", concrete.Value);
-        }
-
-        [Fact]
-        public void BackgroundColorTransparentLegal()
-        {
-            var snippet = "background-color : Transparent";
-            var property = ParseDeclaration(snippet);
-            Assert.Equal("background-color", property.Name);
-            Assert.False(property.IsImportant);
-            Assert.IsType<BackgroundColorProperty>(property);
-            var concrete = (BackgroundColorProperty)property;
-            Assert.False(concrete.IsInherited);
-            Assert.True(concrete.HasValue);
-            Assert.Equal("rgba(0, 0, 0, 0)", concrete.Value);
-        }
-
-        [Fact]
-        public void BackgroundColorHexLegal()
-        {
-            var snippet = "background-color : #bbff00";
-            var property = ParseDeclaration(snippet);
-            Assert.Equal("background-color", property.Name);
-            Assert.False(property.IsImportant);
-            Assert.IsType<BackgroundColorProperty>(property);
-            var concrete = (BackgroundColorProperty)property;
-            Assert.False(concrete.IsInherited);
-            Assert.True(concrete.HasValue);
-            Assert.Equal("rgb(187, 255, 0)", concrete.Value);
+            Assert.Equal(expectedValue, concrete.Value);
         }
 
         [Fact]

--- a/src/ExCSS/Tokens/ColorToken.cs
+++ b/src/ExCSS/Tokens/ColorToken.cs
@@ -7,7 +7,7 @@
         {
         }
 
-        public bool IsValid => Data.Length != 3 && Data.Length != 6;
+        public bool IsValid => Data.Length != 3 && Data.Length != 4 && Data.Length != 6 && Data.Length != 8;
 
         public override string ToValue()
         {

--- a/src/ExCSS/Values/Color.cs
+++ b/src/ExCSS/Values/Color.cs
@@ -270,7 +270,7 @@ namespace ExCSS
 
         public int Value => _hashcode;
         public byte A => _alpha;
-        public double Alpha => _alpha / 255.0;
+        public double Alpha => Math.Round(_alpha / 255.0, 2);
         public byte R => _red;
         public byte G => _green;
         public byte B => _blue;


### PR DESCRIPTION
There are a couple of issues around the parsing of colours which this PR addresses:

- Hex colours of length 4 or 8 were not considered valid and would be rejected
- When converting some colours to RGB, the alpha component wasn't being rounded down and could be output as "rgb(10, 20, 30, 0.0666666667)" for instance which seems a bit daft.

If you look at the [notes](https://developer.mozilla.org/en-US/docs/Web/CSS/hex-color) for the syntax of hex colours, you can see that a valid hex colour can be 3, 4, 6, or 8 characters in length but `ColorToken` was only considering lengths 3 and 6 as correct. This meant that `ValueExtensions.ToColor` would return `null` when presented with one of these even though `Color.FromHex` already caters for all 4 lengths.

The rounding issue could be argued as not being a bug, but all the tools I've seen around HTML colours only output alpha values down to 2DP so this seems a sensible change.

The unit tests for `BackgroundColor` have been updated here to include new examples of inputs which triggered each of these to verify the changes.  The hex colour `#AABBCC11` is an example of something that would output the alpha component to multiple decimal places.