### PR TITLE
@page rule parsing fixes

### DIFF
--- a/src/ExCSS.Tests/Cases.cs
+++ b/src/ExCSS.Tests/Cases.cs
@@ -1022,5 +1022,15 @@ lack; }");
 
             Assert.IsNotType<UnknownProperty>(((StyleRule)document.Rules[0]).Style.Children.First());
         }
+
+        [Theory]
+        [InlineData("@page { margin-bottom: 5pt; margin-top: 5pt }", "@page {margin-bottom: 5pt; margin-top: 5pt; }")]
+        public void PageRuleCSSOutput(string input, string expected)
+        {
+            var parser = new StylesheetParser();
+            var document = parser.Parse(input);
+
+            Assert.Equal(expected, document.ToCss());
+        }
     }
 }

--- a/src/ExCSS.Tests/Cases.cs
+++ b/src/ExCSS.Tests/Cases.cs
@@ -1025,6 +1025,7 @@ lack; }");
 
         [Theory]
         [InlineData("@page { margin-bottom: 5pt; margin-top: 5pt }", "@page {margin-bottom: 5pt; margin-top: 5pt; }")]
+        [InlineData("@page :left { margin-bottom: 5pt; margin-top: 5pt }", "@page :left {margin-bottom: 5pt; margin-top: 5pt; }")]
         public void PageRuleCSSOutput(string input, string expected)
         {
             var parser = new StylesheetParser();

--- a/src/ExCSS/Parser/StylesheetComposer.cs
+++ b/src/ExCSS/Parser/StylesheetComposer.cs
@@ -253,7 +253,6 @@ namespace ExCSS
                 // e.g. @page :left{...}
                 rule.Selector = CreatePageSelector(ref token);
                 ParseComments(ref token);
-                token = NextToken();
             }
 
             if (token.Type == TokenType.CurlyBracketOpen)
@@ -478,6 +477,9 @@ namespace ExCSS
                 // Add the pseudo class selector
                 token = NextToken();
                 selector = token.Type == TokenType.Ident ? new PageSelector(token.Data) : new PageSelector();
+
+                //Skip past the pseudo class identifier
+                token = NextToken();
             }
             else
             {

--- a/src/ExCSS/Rules/PageRule.cs
+++ b/src/ExCSS/Rules/PageRule.cs
@@ -16,7 +16,7 @@ namespace ExCSS
 
         public override void ToCss(TextWriter writer, IStyleFormatter formatter)
         {
-            writer.Write(formatter.Rule("@page", SelectorText, "{"));
+            writer.Write(formatter.Rule("@page", Selector == null ? "" : SelectorText, "{"));
             
             Style.ToCss(writer, formatter);
 


### PR DESCRIPTION
This PR addresses two issues around parsing of @page rules and closes #154 in the process.

The issue from #154 was a NRE when calling `ToCss` on a `PageRule` that did not have a selector set. Since a selector is optional for `@page` rules, the fix here is to simply check whether we have a selector or not in `ToCss` before trying to output it.

A new unit test was added with the example from the bug report to check that the crash no longer occurs.

As part of writing that test, I added additional tests for rules that did have a selector and was surprised to find that in these cases, the parsed page rules collection was empty.

The problem here was when a `@page` rule had a selector (such as `@page :left`, `CreatePageSelector` would consume the colon token for the start of the pseudo-selector but NOT consume the pseudo-selector identifier token itself. This meant that when `ParseComments` was called after parsing the selector, the starting token it saw was an Ident token and so it skipped attempting to parse any comments or skip whitespace. 

The `NextToken` call after `ParseComments` would then potentially leave the current token as a whitespace token, rather than the opening curly-brace to start the declarations and so no declarations would be parsed and no page rule added to the object model.

This has been fixed by consuming the pseudo-selector identifier token in `CreatePageSelector` so that the call to `ParseComments` will skip over any comments and whitespace. As a result, `ParseComments` will now exit when the current token is the opening curly brace so the `NextToken` call after `ParseComments` is not needed.

