### PR TITLE
Use option AllowInvalidSelectors to allow non-standard pseudo element selectors

### DIFF
--- a/.github/actions/dotnet/test/action.yml
+++ b/.github/actions/dotnet/test/action.yml
@@ -22,7 +22,7 @@ runs:
       run: dotnet test --logger trx --results-directory ${{ inputs.results-directory }} --no-build --configuration ${{ inputs.dotnet-build-configuration }} --verbosity normal
 
     - name: Parse the unit test files
-      uses: nasamin/trx-parser@v0.2.0
+      uses: nasamin/trx-parser@v0.5.0
       with:
         TRX_PATH: ${{ github.workspace }}/test-results
         REPO_TOKEN: ${{ inputs.github-token }}

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ The goal of ExCSS is to make it easy to read and parse stylesheets into a friend
 Version 4 is a move forward in framework support.  The new version targets the latest version of .NET; Core 3.1 and 4.8.  The API surface is the same as version 3, but will target the future-facing, unified .NET version including the upcoming .NET 5. Version 3 was rewritten from the ground up; version 4 makes full use of those enhancements plus new additions under development!  This is the most advanced ExCSS parser to date.  The parser has been rebuild to have better white spaces support as well as the ability to handle unknown rule sets in the ever-changing web and CSS landscape.
 
 # NuGet
-[![NuGet Status](https://img.shields.io/nuget/v/excss.svg)](https://www.nuget.org/packages/excss/)
+[![NuGet Status](https://img.shields.io/nuget/v/Anateus.ExCSS.svg)](https://www.nuget.org/packages/Anateus.ExCSS/)
 
 # Lexing and Parsing - How it all Works
 ExCSS uses a Lexer and a Parser based on a CSS3-specific grammar. The Lexer and Parser read CSS text and parse each 

--- a/src/ExCSS.Tests/Cases.cs
+++ b/src/ExCSS.Tests/Cases.cs
@@ -891,7 +891,7 @@ tobi loki jane {
 
             var marginRule = pageRule.Children.Last() as MarginStyleRule;
             Assert.Equal("@bottom-right", marginRule.SelectorText);
-            Assert.Equal(1, marginRule.Style.Children.Count());
+            Assert.Single(marginRule.Style.Children);
             Assert.Equal("color: rgb(0, 0, 0)", (marginRule.Style.Children.First() as ColorProperty).CssText);
         }
 

--- a/src/ExCSS.Tests/DocumentFunction.cs
+++ b/src/ExCSS.Tests/DocumentFunction.cs
@@ -13,7 +13,7 @@
             var rule = ParseRule(snippet) as DocumentRule;
             Assert.NotNull(rule);
             Assert.Equal(RuleType.Document, rule.Type);
-            Assert.Equal(1, rule.Conditions.Count());
+            Assert.Single(rule.Conditions);
             var condition = rule.Conditions.First();
             Assert.Equal("url", condition.Name);
             Assert.Equal("http://www.w3.org/", condition.Data);
@@ -28,7 +28,7 @@
             var rule = ParseRule(snippet) as DocumentRule;
             Assert.NotNull(rule);
             Assert.Equal(RuleType.Document, rule.Type);
-            Assert.Equal(1, rule.Conditions.Count());
+            Assert.Single(rule.Conditions);
             var condition = rule.Conditions.First();
             Assert.Equal("url-prefix", condition.Name);
             Assert.Equal("http://www.w3.org/Style/", condition.Data);
@@ -43,7 +43,7 @@
             var rule = ParseRule(snippet) as DocumentRule;
             Assert.NotNull(rule);
             Assert.Equal(RuleType.Document, rule.Type);
-            Assert.Equal(1, rule.Conditions.Count());
+            Assert.Single(rule.Conditions);
             var condition = rule.Conditions.First();
             Assert.Equal("domain", condition.Name);
             Assert.Equal("mozilla.org", condition.Data);
@@ -60,7 +60,7 @@
             var rule = ParseRule(snippet) as DocumentRule;
             Assert.NotNull(rule);
             Assert.Equal(RuleType.Document, rule.Type);
-            Assert.Equal(1, rule.Conditions.Count());
+            Assert.Single(rule.Conditions);
             var condition = rule.Conditions.First();
             Assert.Equal("regexp", condition.Name);
             Assert.Equal("https:.*", condition.Data);

--- a/src/ExCSS.Tests/Flexbox.cs
+++ b/src/ExCSS.Tests/Flexbox.cs
@@ -202,7 +202,7 @@ namespace ExCSS.Tests
                     new object[] { "row nowrap" },
                     new object[] { "column wrap" },
                     new object[] { "column-reverse wrap-reverse" },
-                }.Union(GlobalKeywordTestValues.ToObjectArray());
+                }.Union(GlobalKeywordTestValues.ToObjectArray(), ObjectArrayComparer.Instance);
             }
         }
 
@@ -235,7 +235,7 @@ namespace ExCSS.Tests
                     new object[] { "1 30px" },
                     new object[] { "2 2" },
                     new object[] { "2 2 10%" },
-                }.Union(GlobalKeywordTestValues.ToObjectArray());
+                }.Union(GlobalKeywordTestValues.ToObjectArray(), ObjectArrayComparer.Instance);
             }
         }
 
@@ -260,7 +260,7 @@ namespace ExCSS.Tests
                     new object[] { Keywords.Stretch },
                     new object[] { $"{Keywords.Safe} {Keywords.Center}" },
                     new object[] { $"{Keywords.Unsafe} {Keywords.Center}" },
-                }.Union(GlobalKeywordTestValues.ToObjectArray());
+                }.Union(GlobalKeywordTestValues.ToObjectArray(), ObjectArrayComparer.Instance);
             }
         }
 
@@ -283,7 +283,7 @@ namespace ExCSS.Tests
                     new object[] { $"{Keywords.Last} {Keywords.Baseline}" },
                     new object[] { $"{Keywords.Safe} {Keywords.Center}" },
                     new object[] { $"{Keywords.Unsafe} {Keywords.Center}" },
-                }.Union(GlobalKeywordTestValues.ToObjectArray());
+                }.Union(GlobalKeywordTestValues.ToObjectArray(), ObjectArrayComparer.Instance);
             }
         }
 
@@ -307,7 +307,7 @@ namespace ExCSS.Tests
                     new object[] { Keywords.Stretch },
                     new object[] { $"{Keywords.Safe} {Keywords.Center}" },
                     new object[] { $"{Keywords.Unsafe} {Keywords.Center}" },
-                }.Union(GlobalKeywordTestValues.ToObjectArray());
+                }.Union(GlobalKeywordTestValues.ToObjectArray(), ObjectArrayComparer.Instance);
             }
         }
 
@@ -331,7 +331,7 @@ namespace ExCSS.Tests
                     new object[] { $"{Keywords.Last} {Keywords.Baseline}" },
                     new object[] { $"{Keywords.Safe} {Keywords.Center}" },
                     new object[] { $"{Keywords.Unsafe} {Keywords.Center}" },
-                }.Union(GlobalKeywordTestValues.ToObjectArray());
+                }.Union(GlobalKeywordTestValues.ToObjectArray(), ObjectArrayComparer.Instance);
             }
         }
 
@@ -356,7 +356,7 @@ namespace ExCSS.Tests
                     new object[] { $"{Keywords.First} {Keywords.End}" },
                     new object[] { $"{Keywords.First} {Keywords.FlexStart}" },
                     new object[] { $"{Keywords.First} {Keywords.FlexEnd}" },
-                
+
                     new object[] { $"{Keywords.Last} {Keywords.Start}" },
                     new object[] { $"{Keywords.Last} {Keywords.End}" },
                     new object[] { $"{Keywords.Last} {Keywords.FlexStart}" },
@@ -433,7 +433,7 @@ namespace ExCSS.Tests
                 {
                     new object[] { "3" },
                     new object[] { "0.6" }
-                }.Union(GlobalKeywordTestValues.ToObjectArray());
+                }.Union(GlobalKeywordTestValues.ToObjectArray(), ObjectArrayComparer.Instance);
             }
         }
 
@@ -451,7 +451,7 @@ namespace ExCSS.Tests
                     new object[] { Keywords.FitContent },
                     new object[] { Keywords.Content },
                     new object[] { Keywords.Auto }
-                }.Union(GlobalKeywordTestValues.ToObjectArray());
+                }.Union(GlobalKeywordTestValues.ToObjectArray(), ObjectArrayComparer.Instance);
             }
         }
 
@@ -463,7 +463,7 @@ namespace ExCSS.Tests
                 {
                     new object[] { "-1" },
                     new object[] { "1" },
-                }.Union(GlobalKeywordTestValues.ToObjectArray());
+                }.Union(GlobalKeywordTestValues.ToObjectArray(), ObjectArrayComparer.Instance);
             }
         }
     }

--- a/src/ExCSS.Tests/KeyframeRule.cs
+++ b/src/ExCSS.Tests/KeyframeRule.cs
@@ -13,8 +13,8 @@
   }");
             Assert.NotNull(rule);
             Assert.Equal("0%", rule.KeyText);
-            Assert.Equal(1, rule.Key.Stops.Count());
-            Assert.Equal(1, rule.Style.Declarations.Count());
+            Assert.Single(rule.Key.Stops);
+            Assert.Single(rule.Style.Declarations);
             Assert.Equal("margin-left", rule.Style.Declarations.First().Name);
         }
 
@@ -27,7 +27,7 @@
   }");
             Assert.NotNull(rule);
             Assert.Equal("50%", rule.KeyText);
-            Assert.Equal(1, rule.Key.Stops.Count());
+            Assert.Single(rule.Key.Stops);
             Assert.Equal(2, rule.Style.Declarations.Count());
             Assert.Equal("margin-left", rule.Style.Declarations.Skip(0).First().Name);
             Assert.Equal("opacity", rule.Style.Declarations.Skip(1).First().Name);
@@ -41,8 +41,8 @@
   }");
             Assert.NotNull(rule);
             Assert.Equal("100%", rule.KeyText);
-            Assert.Equal(1, rule.Key.Stops.Count());
-            Assert.Equal(1, rule.Style.Declarations.Count());
+            Assert.Single(rule.Key.Stops);
+            Assert.Single(rule.Style.Declarations);
             Assert.Equal("margin-left", rule.Style.Declarations.First().Name);
         }
 
@@ -69,8 +69,8 @@
             var rule = ParseKeyframeRule(@"  0% { }");
             Assert.NotNull(rule);
             Assert.Equal("0%", rule.KeyText);
-            Assert.Equal(1, rule.Key.Stops.Count());
-            Assert.Equal(0, rule.Style.Declarations.Count());
+            Assert.Single(rule.Key.Stops);
+            Assert.Empty(rule.Style.Declarations);
         }
     }
 }

--- a/src/ExCSS.Tests/ObjectArrayComparer.cs
+++ b/src/ExCSS.Tests/ObjectArrayComparer.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace ExCSS.Tests
+{
+    class ObjectArrayComparer : IEqualityComparer, IEqualityComparer<object[]>
+    {
+        public static readonly ObjectArrayComparer Instance = new ObjectArrayComparer();
+        public bool Equals(object[] x, object[] y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+
+            if (x == null || y == null)
+                return false;
+
+            if (x.Length != y.Length)
+                return false;
+
+            var comparer = EqualityComparer<object>.Default;
+            for (int i = 0; i < x.Length; i++)
+            {
+                if (!comparer.Equals(x[i], x[i])) return false;
+            }
+            return true;
+        }
+
+        public int GetHashCode(object[] obj)
+        {
+            if (obj == null || obj.Length == 0)
+                return 0;
+
+            int hash = obj[0]?.GetHashCode() ?? 0;
+            var comparer = EqualityComparer<object>.Default;
+            for (int i = 1; i < obj.Length; i++)
+            {
+                uint temp = (uint)(hash << 5) | ((uint)hash >> 27);
+                hash = ((int)temp + hash) ^ (obj[i]?.GetHashCode() ?? 0);
+            }
+            return hash;
+        }
+
+        bool IEqualityComparer.Equals(object x, object y)
+        {
+            if (x == y)
+                return true;
+            if (x == null || y == null)
+                return false;
+            if (x is object[] && y is object[])
+                return Equals((object[])x, (object[])y);
+
+            throw new ArgumentException("Type of argument is not compatible with this comparer.");
+        }
+
+        int IEqualityComparer.GetHashCode(object obj)
+        {
+            if (obj == null)
+                return 0;
+            if (obj is object[])
+                return GetHashCode((object[])obj);
+
+            throw new ArgumentException("Type of argument is not compatible with this comparer.");
+        }
+    }
+}

--- a/src/ExCSS.Tests/PropertyTests/GapProperty.cs
+++ b/src/ExCSS.Tests/PropertyTests/GapProperty.cs
@@ -39,7 +39,7 @@ namespace ExCSS.Tests.PropertyTests
                     new object[] { "0.5cm 2mm" },
                     new object[] { "16% 100%" },
                     new object[] { "21px 82%" }
-                }.Union(LengthOrPercentOrGlobalTestValues.Union(GlobalKeywordTestValues.ToObjectArray()));
+                }.Union(LengthOrPercentOrGlobalTestValues.Union(GlobalKeywordTestValues.ToObjectArray(), ObjectArrayComparer.Instance), ObjectArrayComparer.Instance);
             }
         }
 

--- a/src/ExCSS.Tests/PropertyTests/TextProperty.cs
+++ b/src/ExCSS.Tests/PropertyTests/TextProperty.cs
@@ -403,6 +403,7 @@
 			Assert.IsType<WordBreakProperty>(property);
 		}
 
+        [Fact]
 		public void TextAlignLastAutoLegal()
 		{
 			var snippet = "text-align-last: auto";

--- a/src/ExCSS.Tests/Sheet.cs
+++ b/src/ExCSS.Tests/Sheet.cs
@@ -391,11 +391,11 @@ h1 { color: blue }");
             var valueString = "24px 12px 6px";
             var list = ParseValue(valueString);
             Assert.Equal(5, list.Count);
-            Assert.Equal(list[0].ToValue(), "24px");
-            Assert.Equal(list[1].ToValue(), " ");
-            Assert.Equal(list[2].ToValue(), "12px");
-            Assert.Equal(list[3].ToValue(), " ");
-            Assert.Equal(list[4].ToValue(), "6px");
+            Assert.Equal("24px", list[0].ToValue());
+            Assert.Equal(" ", list[1].ToValue());
+            Assert.Equal("12px", list[2].ToValue());
+            Assert.Equal(" ", list[3].ToValue());
+            Assert.Equal("6px", list[4].ToValue());
         }
 
         [Fact]
@@ -404,13 +404,13 @@ h1 { color: blue }");
             var valueString = "  24px  12px 6px  13px ";
             var list = ParseValue(valueString);
             Assert.Equal(7, list.Count);
-            Assert.Equal(list[0].ToValue(), "24px");
-            Assert.Equal(list[1].ToValue(), " ");
-            Assert.Equal(list[2].ToValue(), "12px");
-            Assert.Equal(list[3].ToValue(), " ");
-            Assert.Equal(list[4].ToValue(), "6px");
-            Assert.Equal(list[5].ToValue(), " ");
-            Assert.Equal(list[6].ToValue(), "13px");
+            Assert.Equal("24px", list[0].ToValue());
+            Assert.Equal(" ", list[1].ToValue());
+            Assert.Equal("12px", list[2].ToValue());
+            Assert.Equal(" ", list[3].ToValue());
+            Assert.Equal("6px", list[4].ToValue());
+            Assert.Equal(" ", list[5].ToValue());
+            Assert.Equal("13px", list[6].ToValue());
         }
 
         [Fact]
@@ -552,7 +552,7 @@ h1 { color: blue }");
                 Assert.Equal(names[i], decl.Name);
                 Assert.Equal(propertyName, decl.Name);
                 Assert.False(decl.IsImportant);
-                Assert.Equal("20px", decl.Value);   
+                Assert.Equal("20px", decl.Value);
             }
         }
 
@@ -952,7 +952,7 @@ p.info span::after {
         [Fact(Timeout = 1000)]
         public void CssParseSheetWithAtAndCommentDoesNotTakeForever3()
         {
-            var sheet = ParseStyleSheet( @"
+            var sheet = ParseStyleSheet(@"
 @media (max-width: 991px) {
     body {
         background-color: #013668;
@@ -1057,12 +1057,12 @@ font-weight:bold;}";
         public void CssStyleSheetInsertAndDeleteShouldWork()
         {
             var parser = new StylesheetParser();
-		    var s = new Stylesheet(parser);
+            var s = new Stylesheet(parser);
             Assert.Equal(0, s.Rules.Length);
-            
+
             s.Insert("a {color: blue}", 0);
             Assert.Equal(1, s.Rules.Length);
-            
+
             s.Insert("a *:first-child, a img {border: none}", 1);
             Assert.Equal(2, s.Rules.Length);
 
@@ -1110,13 +1110,13 @@ font-weight:bold;}";
             const string source = ".foo { color: red; } @media print { #myid { color: green; } }";
             var sheet = parser.Parse(source);
             var comments = sheet.GetComments();
-            Assert.Equal(0, comments.Count());
+            Assert.Empty(comments);
         }
 
         [Fact]
         public void CssStyleSheetWithCommentInDeclaration()
         {
-            var parser = new StylesheetParser(preserveComments:true);
+            var parser = new StylesheetParser(preserveComments: true);
             const string source = ".foo { /*test*/ color: red;/*test*/ } @media print { #myid { color: green; } }";
             var sheet = parser.Parse(source);
             var comments = sheet.GetComments();
@@ -1168,7 +1168,7 @@ font-weight:bold;}";
             Assert.Equal(source, roundtrip);
         }
 
-       
+
         [Fact]
         public void CssStyleSheetSelectorsGetAll()
         {

--- a/src/ExCSS/Directory.Build.targets
+++ b/src/ExCSS/Directory.Build.targets
@@ -1,0 +1,16 @@
+<!-- https://github.com/clairernovotny/DeterministicBuilds -->
+<!-- Workaround. Remove once we're on 3.1.300+
+https://github.com/dotnet/sourcelink/issues/572 -->
+<Project>
+  <PropertyGroup>
+    <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
+  </ItemGroup>
+
+  <!-- Workaround for https://github.com/dotnet/sdk/issues/11105 -->
+  <ItemGroup>
+    <SourceRoot Include="$(NuGetPackageRoot)" Condition="'$(NuGetPackageRoot)' != ''" />
+  </ItemGroup>  
+</Project>

--- a/src/ExCSS/ExCSS.csproj
+++ b/src/ExCSS/ExCSS.csproj
@@ -4,25 +4,41 @@
 		<LangVersion>9.0</LangVersion>
 		<TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net48;netstandard2.1;netstandard2.0</TargetFrameworks>
 		<AssemblyName>ExCSS</AssemblyName>
-		<PackageId>ExCSS</PackageId>
+		<PackageId>Anateus.ExCSS</PackageId>
 		<Title>ExCSS .NET Stylesheet Parser</Title>
-		<Authors>Tyler Brinks</Authors>
+		<Authors>Anateus,Tyler Brinks</Authors>
 		<Description>
 			ExCSS is a CSS 2.1 and CSS 3 parser for .NET. 
 			ExCSS makes it easy to read and parse stylesheets into a friendly object model with full LINQ support.
 		</Description>
-		<PackageProjectUrl>https://github.com/TylerBrinks/ExCSS</PackageProjectUrl>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageReadmeFile>readme.md</PackageReadmeFile>
-        <RespositoryType>git</RespositoryType>
-        <RepositoryUrl>https://github.com/TylerBrinks/ExCSS</RepositoryUrl>
+		<PackageProjectUrl>https://github.com/matherm-aboehm/ExCSS</PackageProjectUrl>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageReadmeFile>readme.md</PackageReadmeFile>
+		<RespositoryType>git</RespositoryType>
+		<RepositoryUrl>https://github.com/matherm-aboehm/ExCSS</RepositoryUrl>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>ExCSS.snk</AssemblyOriginatorKeyFile>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<!-- If snupkg can't be used, the PDBs can be included in the main nupkg
+		see: https://github.com/dotnet/sourcelink/blob/main/README.md
+		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+		-->
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(TargetFramework)' != ''">
+		<LangVersion>9.0</LangVersion>
+	</PropertyGroup>
+	
+	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+	</PropertyGroup>
+	
 	<ItemGroup>
 		<None Remove="ExCSS.snk" />
 	</ItemGroup>
@@ -30,6 +46,13 @@
 	<ItemGroup>
 		<Folder Include="Properties\" />
 		<None Include="..\..\readme.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 </Project>

--- a/src/ExCSS/Factories/PseudoElementSelectorFactory.cs
+++ b/src/ExCSS/Factories/PseudoElementSelectorFactory.cs
@@ -9,6 +9,8 @@ namespace ExCSS
         private static readonly Lazy<PseudoElementSelectorFactory> Lazy =
             new(() => new PseudoElementSelectorFactory());
 
+        private readonly StylesheetParser _parser;
+
         #region Selectors
 
         private readonly Dictionary<string, ISelector> _selectors =
@@ -27,15 +29,18 @@ namespace ExCSS
 
         #endregion
 
-        private PseudoElementSelectorFactory()
+        internal PseudoElementSelectorFactory(StylesheetParser parser = null)
         {
+            _parser = parser;
         }
 
         internal static PseudoElementSelectorFactory Instance => Lazy.Value;
 
         public ISelector Create(string name)
         {
-            return _selectors.TryGetValue(name, out var selector) ? selector : null;
+            return _selectors.TryGetValue(name, out var selector) ? selector :
+                ((_parser?.Options.AllowInvalidSelectors ?? false) ?
+                PseudoElementSelector.Create(name) : null);
         }
     }
 }

--- a/src/ExCSS/Parser/StylesheetParser.cs
+++ b/src/ExCSS/Parser/StylesheetParser.cs
@@ -98,7 +98,7 @@ namespace ExCSS
         {
             var attributeSelector = AttributeSelectorFactory.Instance;
             var pseudoClassSelector = PseudoClassSelectorFactory.Instance;
-            var pseudoElementSelector = PseudoElementSelectorFactory.Instance;
+            var pseudoElementSelector = new PseudoElementSelectorFactory(this);
             return Pool.NewSelectorConstructor(attributeSelector, pseudoClassSelector, pseudoElementSelector);
         }
 


### PR DESCRIPTION
Most CSS in production uses non-standard names for pseudo element selectors to get a more specific look and feel in most modern browsers, e.g.  [::-webkit-inner-spin-button](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-inner-spin-button). Even your own test file `bootstrap.css` for unit tests contains them.
The current code base (Version 4.2.4) has no option to allow these non-standard names for the parser.
So, I created my own NuGet package for this feature.

To do this with GitHub Actions in my fork, I had to change the package information, so that it includes the right repository URLs and owner prefix for my own NuGet space.
You need to remove or edit commit a0e59919f09477cf916de99f05606a5ffa5b2f92 from this PR to restore the previous build pipeline.

This fixes #69.