### PR TITLE
Expose font default values

### DIFF
--- a/src/ExCSS.Tests/FontProperty.cs
+++ b/src/ExCSS.Tests/FontProperty.cs
@@ -735,6 +735,48 @@
         }
 
         [Fact]
+        public void CssFontInitialAll()
+        {
+            var snippet = "font: initial ";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("font", property.Name);
+            Assert.False(property.IsImportant);
+            Assert.IsType<FontProperty>(property);
+            var concrete = (FontProperty)property;
+            Assert.True(concrete.IsInherited);
+            Assert.True(concrete.HasValue);
+            Assert.Equal("initial", concrete.Value);
+        }
+
+        [Fact]
+        public void CssFontInheritAll()
+        {
+            var snippet = "font: inherit ";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("font", property.Name);
+            Assert.False(property.IsImportant);
+            Assert.IsType<FontProperty>(property);
+            var concrete = (FontProperty)property;
+            Assert.True(concrete.IsInherited);
+            Assert.True(concrete.HasValue);
+            Assert.Equal("inherit", concrete.Value);
+        }
+
+        [Fact]
+        public void CssFontUnsetAll()
+        {
+            var snippet = "font: unset ";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("font", property.Name);
+            Assert.False(property.IsImportant);
+            Assert.IsType<FontProperty>(property);
+            var concrete = (FontProperty)property;
+            Assert.False(concrete.IsInherited);
+            Assert.True(concrete.HasValue);
+            Assert.Equal("unset", concrete.Value);
+        }
+
+        [Fact]
         public void CssFontFaceWithThreeRulesShouldSerializeCorrectly()
         {
             var snippet = @"@font-face {

--- a/src/ExCSS/StyleProperties/Font/FontProperty.cs
+++ b/src/ExCSS/StyleProperties/Font/FontProperty.cs
@@ -13,8 +13,9 @@
             WithOrder(
                 FontSizeConverter.Required().For(PropertyNames.FontSize),
                 LineHeightConverter.StartsWithDelimiter().Option().For(PropertyNames.LineHeight),
-                FontFamiliesConverter.Required().For(PropertyNames.FontFamily))).Or(
-            SystemFontConverter);
+                FontFamiliesConverter.Required().For(PropertyNames.FontFamily)))
+            .Or(SystemFontConverter)
+            .OrGlobalValue();
 
         internal FontProperty()
             : base(PropertyNames.Font, PropertyFlags.Inherited | PropertyFlags.Animatable)


### PR DESCRIPTION
There are cases where a declaration of a font: inherit/initial/unset can matter, so they should be exposed to allow consuming applications to make the correct decision.

For more context, there are cases when these values should override any other font properties that may have been set by other css style selectors (depending on factors such as origin stylesheet, specificity, positioning, and importance tags). An example of what I mean can be found here: https://stackoverflow.com/questions/12880536/what-is-the-purpose-of-using-font-inherit

The example in the answer from that post is not referring to the font property, but the same concept applies. If the font-weight is set to bold on all elements td, but at the same time that same td also has class attributed to it that sets font: inherit (or initial or unset etc.), then that bold font-weight will no longer apply. This is why we need this library to expose such values so this determination can be done by the consuming application.

