### PR TITLE
Refactor opacity parsing and add percent/number converters

### DIFF
--- a/src/ExCSS.Tests/PropertyTests/OpacityPropertyTests.cs
+++ b/src/ExCSS.Tests/PropertyTests/OpacityPropertyTests.cs
@@ -25,16 +25,20 @@ public class OpacityPropertyTests : CssConstructionFunctions
         var result = (OpacityProperty)property;
         Assert.Equal("50%", result.Value);
 
+        property = ParseDeclaration("opacity: 0.4");
+        result = (OpacityProperty)property;
+        Assert.Equal("0.4", result.Value);
+
         property = ParseDeclaration("opacity: .50");
         result = (OpacityProperty)property;
-        Assert.Equal("50%", result.Value);
+        Assert.Equal("0.5", result.Value);
 
         property = ParseDeclaration("opacity: 1");
         result = (OpacityProperty)property;
-        Assert.Equal("100%", result.Value);
+        Assert.Equal("1", result.Value);
 
         property = ParseDeclaration("opacity: 0");
         result = (OpacityProperty)property;
-        Assert.Equal("0%", result.Value);
+        Assert.Equal("0", result.Value);
     }
 }

--- a/src/ExCSS/Extensions/ValueExtensions.cs
+++ b/src/ExCSS/Extensions/ValueExtensions.cs
@@ -138,8 +138,7 @@ namespace ExCSS
 
             try
             {
-                var number = token.Value;
-                return new Number(number, Number.Unit.Float);
+                return new Number(token.Value, Number.Unit.Float);
             }
             catch
             {

--- a/src/ExCSS/Extensions/ValueExtensions.cs
+++ b/src/ExCSS/Extensions/ValueExtensions.cs
@@ -120,6 +120,33 @@ namespace ExCSS
             }
         }
 
+        public static Number? ToPercentOrNumber(this IEnumerable<Token> value)
+        {
+            var enumerable = value as Token[] ?? value.ToArray();
+            var percent = ToPercent(enumerable);
+
+            if (percent is not null)
+            {
+                return new Number(percent.Value.Value, Number.Unit.Percent);
+            }
+
+            var element = value.OnlyOrDefault();
+            if (element is not NumberToken token)
+            {
+                return null;
+            }
+
+            try
+            {
+                var number = token.Value;
+                return new Number(number, Number.Unit.Float);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
         public static string ToCssString(this IEnumerable<Token> value)
         {
             var element = value.OnlyOrDefault();

--- a/src/ExCSS/Model/Converters.cs
+++ b/src/ExCSS/Model/Converters.cs
@@ -70,6 +70,9 @@ namespace ExCSS
         public static readonly IValueConverter PercentOrFractionConverter =
             new StructValueConverter<Percent>(ValueExtensions.ToPercentOrFraction);
 
+        public static readonly IValueConverter PercentOrNumberConverter =
+            new StructValueConverter<Number>(ValueExtensions.ToPercentOrNumber);
+
         public static readonly IValueConverter AngleNumberConverter =
             new StructValueConverter<Angle>(ValueExtensions.ToAngleNumber);
 
@@ -323,6 +326,7 @@ namespace ExCSS
         public static readonly IValueConverter OptionalLengthOrPercentConverter = LengthOrPercentConverter.OrNone();
         public static readonly IValueConverter AutoLengthOrPercentConverter = LengthOrPercentConverter.OrAuto();
         public static readonly IValueConverter OptionalPercentOrFractionConverter = PercentOrFractionConverter.OrDefault(1f);
+        public static readonly IValueConverter OptionalPercentOrNumberConverter = PercentOrNumberConverter.OrDefault(1f);
 
         public static readonly IValueConverter FontSizeConverter =
             LengthOrPercentConverter.Or(Map.FontSizes.ToConverter());

--- a/src/ExCSS/StyleProperties/Visibility/OpacityProperty.cs
+++ b/src/ExCSS/StyleProperties/Visibility/OpacityProperty.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class OpacityProperty : Property
     {
-        private static readonly IValueConverter StyleConverter = Converters.OptionalPercentOrFractionConverter;
+        private static readonly IValueConverter StyleConverter = Converters.OptionalPercentOrNumberConverter;
 
         internal OpacityProperty() : base(PropertyNames.Opacity, PropertyFlags.Animatable)
         {

--- a/src/ExCSS/Values/Number.cs
+++ b/src/ExCSS/Values/Number.cs
@@ -65,7 +65,8 @@ namespace ExCSS
         public enum Unit : byte
         {
             Integer,
-            Float
+            Float,
+            Percent
         }
 
         public static bool operator ==(Number a, Number b)
@@ -90,12 +91,12 @@ namespace ExCSS
 
         public override string ToString()
         {
-            return Value.ToString();
+            return Value.ToString() + (_unit == Unit.Percent ? "%" : string.Empty);
         }
 
         public string ToString(string format, IFormatProvider formatProvider)
         {
-            return Value.ToString(format, formatProvider);
+            return Value.ToString(format, formatProvider) + (_unit == Unit.Percent ? "%" : string.Empty);
         }
     }
 }


### PR DESCRIPTION
The support for percentage values for the "opacity" property, introduced with 4.2.6, results in percentage values being applied to the property after parsing, regardless of the input value.

With this pull request, the behavior has been changed so that a percentage value is only applied if the input was a percentage value.

For this, the "Number" struct was extended with the Percent unit, and appropriate converter methods were added. Additionally, the unit tests were adjusted accordingly.