### PR TITLE
BugFix: Important get's lost in case of Unknown Values.

### DIFF
--- a/src/ExCSS/Parser/StylesheetComposer.cs
+++ b/src/ExCSS/Parser/StylesheetComposer.cs
@@ -657,6 +657,7 @@ namespace ExCSS
 
                             property = new UnknownProperty(propertyName);
                             property.TrySetValue(value);
+                            property.IsImportant = important;
                             _nodes.Push(property);
                         }
                     }


### PR DESCRIPTION
Fixes the issue where the "!important" rule is not applied in the case of an UnknownValue (AllowInvalidValues = true).

In the following CSS, the value is recognized as unknown, but important is ignored.

.moderntable > .moderntable-caption {
  width: min-content !important;
}

The problem was introduced in release 4.2.1