### PR TITLE
Added support for @container queries and comparison operators

### DIFF
--- a/src/ExCSS.Tests/Container.cs
+++ b/src/ExCSS.Tests/Container.cs
@@ -1,0 +1,103 @@
+﻿namespace ExCSS.Tests
+{
+    using ExCSS;
+    using Xunit;
+    using System.Linq;
+
+    public class CssContainerTests : CssConstructionFunctions
+    {
+        [Fact]
+        public void SimpleContainer()
+        {
+            const string source = "@container tall (min-width: 500px) and (min-height: 300px) {h2 { line-height: 1.6; } }";
+            var result = ParseStyleSheet(source);
+            Assert.Equal(source, result.StylesheetText.Text);
+            var rule = result.Rules[0] as ContainerRule;
+            Assert.NotNull(rule);
+            Assert.Equal("@container tall (min-width: 500px) and (min-height: 300px) { h2 { line-height: 1.6 } }", rule.Text);
+            Assert.Equal("tall", rule.Name);
+            Assert.Equal("(min-width: 500px) and (min-height: 300px)", rule.ConditionText);
+            var childRule = rule.Children.OfType<StyleRule>().First();
+            Assert.Equal("h2 { line-height: 1.6 }", childRule.ToCss());
+        }
+
+        [Fact]
+        public void ContainerWithoutName()
+        {
+            const string source = "@container (min-width: 500px) and (min-height: 300px) {h2 { line-height: 1.6; } }";
+            var result = ParseStyleSheet(source);
+            Assert.Equal(source, result.StylesheetText.Text);
+            var rule = result.Rules[0] as ContainerRule;
+            Assert.NotNull(rule);
+            Assert.Equal("@container (min-width: 500px) and (min-height: 300px) { h2 { line-height: 1.6 } }", rule.Text);
+            Assert.Equal(string.Empty, rule.Name);
+            Assert.Equal("(min-width: 500px) and (min-height: 300px)", rule.ConditionText);
+            var childRule = rule.Children.OfType<StyleRule>().First();
+            Assert.Equal("h2 { line-height: 1.6 }", childRule.ToCss());
+        }
+
+        [Fact]
+        public void ContainerWithoutCondition()
+        {
+            const string source = "@container tall {h2 { line-height: 1.6; } }";
+            var result = ParseStyleSheet(source);
+            Assert.Equal(source, result.StylesheetText.Text);
+            var rule = result.Rules[0] as ContainerRule;
+            Assert.NotNull(rule);
+            Assert.Equal("@container tall { h2 { line-height: 1.6 } }", rule.Text);
+            Assert.Equal("tall", rule.Name);
+            Assert.Equal(string.Empty, rule.ConditionText);
+            var childRule = rule.Children.OfType<StyleRule>().First();
+            Assert.Equal("h2 { line-height: 1.6 }", childRule.ToCss());
+        }
+
+        [Fact]
+        public void ContainerWithComparisonOperators()
+        {
+            const string source = "@container tall (width < 500px) and (height >= 300px) {h2 { line-height: 1.6; } }";
+            var result = ParseStyleSheet(source);
+            Assert.Equal(source, result.StylesheetText.Text);
+            var rule = result.Rules[0] as ContainerRule;
+            Assert.NotNull(rule);
+            Assert.Equal("@container tall (width < 500px) and (height >= 300px) { h2 { line-height: 1.6 } }", rule.Text);
+            Assert.Equal("tall", rule.Name);
+            Assert.Equal("(width < 500px) and (height >= 300px)", rule.ConditionText);
+            var childRule = rule.Children.OfType<StyleRule>().First();
+            Assert.Equal("h2 { line-height: 1.6 }", childRule.ToCss());
+        }
+
+        [Fact]
+        public void CSSWithTwoContainers()
+        {
+            const string source = @"li {
+  container-type: inline-size;
+}
+
+@container (min-width: 45ch) {
+  li span {
+    color: rgb(255, 0, 0);
+    font-size: 2rem !important;
+  }
+}
+
+@container (min-width: 70ch) {
+  li span {
+    color: rgb(0, 0, 255);
+    font-size: 3rem !important;
+  }
+}";
+            var result = ParseStyleSheet(source);
+            Assert.Equal(source, result.StylesheetText.Text);
+            Assert.Equal(3, result.Rules.Length);
+            var rule1 = result.Rules[0] as StyleRule;
+            var rule2 = result.Rules[1] as ContainerRule;
+            var rule3 = result.Rules[2] as ContainerRule;
+            Assert.NotNull(rule1);
+            Assert.NotNull(rule2);
+            Assert.NotNull(rule3);
+            Assert.Equal("li { container-type: inline-size }", rule1.ToCss());
+            Assert.Equal("@container (min-width: 45ch) { li span { color: rgb(255, 0, 0); font-size: 2rem !important } }", rule2.ToCss());
+            Assert.Equal("@container (min-width: 70ch) { li span { color: rgb(0, 0, 255); font-size: 3rem !important } }", rule3.ToCss());
+        }
+    }
+}

--- a/src/ExCSS.Tests/MediaList.cs
+++ b/src/ExCSS.Tests/MediaList.cs
@@ -3,7 +3,7 @@
     using ExCSS;
     using Xunit;
     using System;
-    
+
     public class CssMediaListTests : CssConstructionFunctions
     {
         [Fact]
@@ -375,21 +375,48 @@ h1 { color: green }";
         [Fact]
         public void CssMediaListApiWithAppendDeleteAndTextShouldWork()
         {
-            var media = new [] { "handheld", "screen", "only screen and (max-device-width: 480px)" };
+            var media = new[] { "handheld", "screen", "only screen and (max-device-width: 480px)" };
             var p = new StylesheetParser();
-		    var m = new MediaList(p);
+            var m = new MediaList(p);
             Assert.Equal(0, m.Length);
 
-		    m.Add(media[0]);
-		    m.Add(media[1]);
-		    m.Add(media[2]);
+            m.Add(media[0]);
+            m.Add(media[1]);
+            m.Add(media[2]);
 
-		    m.Remove(media[1]);
+            m.Remove(media[1]);
 
             Assert.Equal(2, m.Length);
             Assert.Equal(media[0], m[0]);
             Assert.Equal(media[2], m[1]);
             Assert.Equal(String.Concat(media[0], ", ", media[2]), m.MediaText);
+        }
+
+        [Fact]
+        public void CombinedConditionMediaQueriesLevel4()
+        {
+            const string source = @"/* Traditionelle Syntax */
+@media (min-height: 500px) and (max-height: 800px) {
+  /* Styles */
+  h1 { color: rgb(255, 0, 0); }
+}
+
+/* Mit Vergleichsoperatoren */
+@media (height >= 500px) and (height <= 800px) {
+  /* Gleiche Styles */
+  h1 { color: rgb(255, 0, 0); }
+}";
+            var result = ParseStyleSheet(source);
+            Assert.Equal(source, result.StylesheetText.Text);
+            Assert.Equal(2, result.Rules.Length);
+            var rule1 = result.Rules[0] as MediaRule;
+            var rule2 = result.Rules[1] as MediaRule;
+            Assert.NotNull(rule1);
+            Assert.NotNull(rule2);
+            Assert.Equal("(min-height: 500px) and (max-height: 800px)", rule1.ConditionText);
+            Assert.Equal("(height >= 500px) and (height <= 800px)", rule2.ConditionText);
+            Assert.Equal("@media (min-height: 500px) and (max-height: 800px) { h1 { color: rgb(255, 0, 0) } }", rule1.ToCss());
+            Assert.Equal("@media (height >= 500px) and (height <= 800px) { h1 { color: rgb(255, 0, 0) } }", rule2.ToCss());
         }
     }
 }

--- a/src/ExCSS/Enumerations/ContainerType.cs
+++ b/src/ExCSS/Enumerations/ContainerType.cs
@@ -1,0 +1,9 @@
+﻿namespace ExCSS
+{
+    public enum ContainerType : byte
+    {
+        Normal,
+        Size,
+        InlineSize
+    }
+}

--- a/src/ExCSS/Enumerations/FeatureNames.cs
+++ b/src/ExCSS/Enumerations/FeatureNames.cs
@@ -42,5 +42,7 @@
         public static readonly string Scripting = "scripting";
         public static readonly string Pointer = "pointer";
         public static readonly string Hover = "hover";
+        public static readonly string BlockSize = "block-size";
+        public static readonly string InlineSize = "inline-size";
     }
 }

--- a/src/ExCSS/Enumerations/Keywords.cs
+++ b/src/ExCSS/Enumerations/Keywords.cs
@@ -310,5 +310,7 @@
         public static readonly string Last = "last";
         public static readonly string SelfStart = "self-start";
         public static readonly string SelfEnd = "self-end";
+        public static readonly string Size = "size";
+        public static readonly string InlineSize = "inline-size";
     }
 }

--- a/src/ExCSS/Enumerations/PropertyNames.cs
+++ b/src/ExCSS/Enumerations/PropertyNames.cs
@@ -91,6 +91,8 @@
         public static readonly string ClipRule = "clip-rule";
         public static readonly string Color = "color";
         public static readonly string ColorInterpolationFilters = "color-interpolation-filters";
+        public static readonly string ContainerName= "container-name";
+        public static readonly string ContainerType = "container-type";
         public static readonly string Content = "content";
         public static readonly string CounterIncrement = "counter-increment";
         public static readonly string CounterReset = "counter-reset";

--- a/src/ExCSS/Enumerations/RuleNames.cs
+++ b/src/ExCSS/Enumerations/RuleNames.cs
@@ -12,5 +12,6 @@
         public static readonly string Media = "media";
         public static readonly string Namespace = "namespace";
         public static readonly string Page = "page";
+        public static readonly string Container = "container";
     }
 }

--- a/src/ExCSS/Enumerations/RuleType.cs
+++ b/src/ExCSS/Enumerations/RuleType.cs
@@ -18,6 +18,7 @@
         Document,
         FontFeatureValues,
         Viewport,
-        RegionStyle
+        RegionStyle,
+        Container
     }
 }

--- a/src/ExCSS/Enumerations/TokenType.cs
+++ b/src/ExCSS/Enumerations/TokenType.cs
@@ -29,6 +29,11 @@
         Comma,
         Semicolon,
         Whitespace,
-        EndOfFile
+        EndOfFile,
+        GreaterThan,
+        GreaterThanOrEqual,
+        LessThan,
+        LessThanOrEqual,
+        Equal
     }
 }

--- a/src/ExCSS/Factories/MediaFeatureFactory.cs
+++ b/src/ExCSS/Factories/MediaFeatureFactory.cs
@@ -60,7 +60,9 @@ namespace ExCSS
                 {FeatureNames.UpdateFrequency, () => new UpdateFrequencyMediaFeature()},
                 {FeatureNames.Scripting, () => new ScriptingMediaFeature()},
                 {FeatureNames.Pointer, () => new PointerMediaFeature()},
-                {FeatureNames.Hover, () => new HoverMediaFeature()}
+                {FeatureNames.Hover, () => new HoverMediaFeature()},
+                {FeatureNames.InlineSize, () => new SizeMediaFeature(FeatureNames.InlineSize)},
+                {FeatureNames.BlockSize, () => new SizeMediaFeature(FeatureNames.BlockSize)},
             };
 
         #endregion

--- a/src/ExCSS/Factories/PropertyFactory.cs
+++ b/src/ExCSS/Factories/PropertyFactory.cs
@@ -173,6 +173,8 @@ namespace ExCSS
             AddLonghand(PropertyNames.Clear, () => new ClearProperty());
             AddLonghand(PropertyNames.Clip, () => new ClipProperty(), true);
             AddLonghand(PropertyNames.Color, () => new ColorProperty(), true);
+            AddLonghand(PropertyNames.ContainerName, () => new ContainerNameProperty());
+            AddLonghand(PropertyNames.ContainerType, () => new ContainerTypeProperty());
             AddLonghand(PropertyNames.Content, () => new ContentProperty());
             AddLonghand(PropertyNames.CounterIncrement, () => new CounterIncrementProperty());
             AddLonghand(PropertyNames.CounterReset, () => new CounterResetProperty());

--- a/src/ExCSS/Formatting/CompressedStyleFormatter.cs
+++ b/src/ExCSS/Formatting/CompressedStyleFormatter.cs
@@ -15,9 +15,9 @@ namespace ExCSS
             return string.Concat(name, ": ", rest);
         }
 
-        string IStyleFormatter.Constraint(string name, string value)
+        string IStyleFormatter.Constraint(string name, string value, string constraintDelimiter)
         {
-            var ending = value != null ? ": " + value : string.Empty;
+            var ending = value != null ? constraintDelimiter + value : string.Empty;
             return string.Concat("(", name, ending, ")");
         }
 

--- a/src/ExCSS/MediaFeatures/MediaFeature.cs
+++ b/src/ExCSS/MediaFeatures/MediaFeature.cs
@@ -1,10 +1,12 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace ExCSS
 {
     public abstract class MediaFeature : StylesheetNode, IMediaFeature
     {
         private TokenValue _tokenValue;
+        private TokenType _constraintDelimiter;
 
         internal MediaFeature(string name)
         {
@@ -27,11 +29,29 @@ namespace ExCSS
 
         public override void ToCss(TextWriter writer, IStyleFormatter formatter)
         {
+            var constraintDelimiter = GetConstraintDelimiter();
             var value = HasValue ? Value : null;
-            writer.Write(formatter.Constraint(Name, value));
+            writer.Write(formatter.Constraint(Name, value, GetConstraintDelimiter()));
         }
 
-        internal bool TrySetValue(TokenValue tokenValue)
+        private string GetConstraintDelimiter()
+        {
+            if (_constraintDelimiter == TokenType.Colon)
+                return ": ";
+            if (_constraintDelimiter == TokenType.GreaterThan)
+                return " > ";
+            if (_constraintDelimiter == TokenType.LessThan)
+                return " < ";
+            if (_constraintDelimiter == TokenType.Equal)
+                return " = ";
+            if (_constraintDelimiter == TokenType.GreaterThanOrEqual)
+                return " >= ";
+            if (_constraintDelimiter == TokenType.LessThanOrEqual)
+                return " <= ";
+            return ": ";
+        }
+
+        internal bool TrySetValue(TokenValue tokenValue, TokenType constraintDelimiter)
         {
             bool result;
 
@@ -41,6 +61,8 @@ namespace ExCSS
                 result = Converter.Convert(tokenValue) != null;
 
             if (result) _tokenValue = tokenValue;
+
+            _constraintDelimiter = constraintDelimiter;
 
             return result;
         }

--- a/src/ExCSS/MediaFeatures/SizeMediaFeature.cs
+++ b/src/ExCSS/MediaFeatures/SizeMediaFeature.cs
@@ -1,0 +1,11 @@
+﻿namespace ExCSS
+{
+    internal sealed class SizeMediaFeature : MediaFeature
+    {
+        public SizeMediaFeature(string name) : base(name)
+        {
+        }
+
+        internal override IValueConverter Converter => Converters.LengthConverter;
+    }
+}

--- a/src/ExCSS/Model/Converters.cs
+++ b/src/ExCSS/Model/Converters.cs
@@ -264,6 +264,7 @@ namespace ExCSS
         public static readonly IValueConverter OverflowModeConverter = Map.OverflowModes.ToConverter();
         public static readonly IValueConverter FloatingConverter = Map.FloatingModes.ToConverter();
         public static readonly IValueConverter DisplayModeConverter = Map.DisplayModes.ToConverter();
+        public static readonly IValueConverter ContainerTypeConverter = Map.ContainerTypes.ToConverter();
         public static readonly IValueConverter ClearModeConverter = Map.ClearModes.ToConverter();
         public static readonly IValueConverter FontStretchConverter = Map.FontStretches.ToConverter();
         public static readonly IValueConverter FontStyleConverter = Map.FontStyles.ToConverter();

--- a/src/ExCSS/Model/IStyleFormatter.cs
+++ b/src/ExCSS/Model/IStyleFormatter.cs
@@ -9,7 +9,7 @@ namespace ExCSS
         string Declaration(string name, string value, bool important);
         string Declarations(IEnumerable<string> declarations);
         string Medium(bool exclusive, bool inverse, string type, IEnumerable<IStyleFormattable> constraints);
-        string Constraint(string name, string value);
+        string Constraint(string name, string value, string constraintDelimiter);
         string Rule(string name, string value);
         string Rule(string name, string prelude, string rules);
         string Style(string selector, IStyleFormattable rules);

--- a/src/ExCSS/Model/Map.cs
+++ b/src/ExCSS/Model/Map.cs
@@ -592,5 +592,13 @@ namespace ExCSS
                 { Keywords.SelfEnd, AlignItem.SelfEnd },
                 { Keywords.Baseline, AlignItem.Baseline },
             };
+
+        public static readonly Dictionary<string, ContainerType> ContainerTypes =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                {Keywords.Normal, ContainerType.Normal},
+                {Keywords.Size, ContainerType.Size},
+                {Keywords.InlineSize, ContainerType.InlineSize}
+            };
     }
 }

--- a/src/ExCSS/Model/ParserExtensions.cs
+++ b/src/ExCSS/Model/ParserExtensions.cs
@@ -138,6 +138,8 @@ namespace ExCSS
                     return new KeyframesRule(parser);
                 case RuleType.Media:
                     return new MediaRule(parser);
+                case RuleType.Container:
+                    return new ContainerRule(parser);
                 case RuleType.Namespace:
                     return new NamespaceRule(parser);
                 case RuleType.Page:

--- a/src/ExCSS/Model/StyleDeclaration.cs
+++ b/src/ExCSS/Model/StyleDeclaration.cs
@@ -842,6 +842,18 @@ namespace ExCSS
             set => SetPropertyValue(PropertyNames.ColumnWidth, value);
         }
 
+        public string ContainerName
+        {
+            get => GetPropertyValue(PropertyNames.ContainerName);
+            set => SetPropertyValue(PropertyNames.ContainerName, value);
+        }
+
+        public string ContainerType
+        {
+            get => GetPropertyValue(PropertyNames.ContainerType);
+            set => SetPropertyValue(PropertyNames.ContainerType, value);
+        }
+
         public string Content
         {
             get => GetPropertyValue(PropertyNames.Content);

--- a/src/ExCSS/Model/Stylesheet.cs
+++ b/src/ExCSS/Model/Stylesheet.cs
@@ -21,6 +21,7 @@ namespace ExCSS
         public IEnumerable<ICharsetRule> CharacterSetRules => Rules.Where(r => r is CharsetRule).Cast<ICharsetRule>();
         public IEnumerable<IFontFaceRule> FontfaceSetRules => Rules.Where(r => r is FontFaceRule).Cast<IFontFaceRule>();
         public IEnumerable<IMediaRule> MediaRules => Rules.Where(r => r is MediaRule).Cast<IMediaRule>();
+        public IEnumerable<IContainerRule> ContainerRules => Rules.Where(r => r is ContainerRule).Cast<IContainerRule>();
         public IEnumerable<IImportRule> ImportRules => Rules.Where(r => r is ImportRule).Cast<IImportRule>();
 
         public IEnumerable<INamespaceRule> NamespaceRules =>

--- a/src/ExCSS/Model/ValueBuilder.cs
+++ b/src/ExCSS/Model/ValueBuilder.cs
@@ -55,6 +55,10 @@ namespace ExCSS
                 case TokenType.Url:
                 case TokenType.Number:
                 case TokenType.Comma:
+                case TokenType.GreaterThan:
+                case TokenType.GreaterThanOrEqual:
+                case TokenType.LessThan:
+                case TokenType.LessThanOrEqual:
                     Add(token);
                     break;
                 case TokenType.Comment:

--- a/src/ExCSS/Parser/Lexer.cs
+++ b/src/ExCSS/Parser/Lexer.cs
@@ -129,19 +129,29 @@ namespace ExCSS
                     return NewSemicolon();
                 case Symbols.LessThan:
                     current = GetNext();
-                    if (current != Symbols.ExclamationMark) return NewDelimiter(GetPrevious());
-                    current = GetNext();
-                    if (current == Symbols.Minus)
+                    if (current == Symbols.ExclamationMark)
                     {
                         current = GetNext();
-                        if (current == Symbols.Minus) return NewOpenComment();
-                        // ReSharper disable once RedundantAssignment
-                        current = GetPrevious();
+                        if (current == Symbols.Minus)
+                        {
+                            current = GetNext();
+                            if (current == Symbols.Minus) return NewOpenComment();
+                            // ReSharper disable once RedundantAssignment
+                            current = GetPrevious();
+                        }
+
+                        GetPrevious();
+                        return NewDelimiter(GetPrevious());
+                    } 
+                    else if (current == Symbols.Equality)
+                    {
+                        Advance();
+                        return NewLessThanOrEqual();
                     }
-
-                    GetPrevious();
-                    return NewDelimiter(GetPrevious());
-
+                    else
+                    {
+                        return NewLessThan();
+                    }
                 case Symbols.At:
                     return AtKeywordStart();
                 case Symbols.SquareBracketOpen:
@@ -199,6 +209,13 @@ namespace ExCSS
                     return current == Symbols.Equality
                         ? NewMatch(Combinators.Unlike)
                         : NewDelimiter(GetPrevious());
+                case Symbols.GreaterThan:
+                    if (GetNext() == Symbols.Equality)
+                    {
+                        Advance();
+                        return NewGreaterThanOrEqual();
+                    }
+                    return NewGreaterThan();
                 default:
                     return current.IsNameStart() ? IdentStart(current) : NewDelimiter(current);
             }
@@ -1080,6 +1097,13 @@ namespace ExCSS
         {
             return new(TokenType.EndOfFile, string.Empty, _position);
         }
+
+        private Token NewGreaterThan() => new Token(TokenType.GreaterThan, ">", _position);
+        private Token NewGreaterThanOrEqual() => new Token(TokenType.GreaterThanOrEqual, ">=", _position);
+        private Token NewLessThan() => new Token(TokenType.LessThan, "<", _position);
+        private Token NewLessThanOrEqual() => new Token(TokenType.LessThanOrEqual, "<=", _position);
+        private Token NewEqual() => new Token(TokenType.Equal, "=", _position);
+
 
         private Token NumberExponential(char letter)
         {

--- a/src/ExCSS/Parser/SelectorConstructor.cs
+++ b/src/ExCSS/Parser/SelectorConstructor.cs
@@ -176,6 +176,9 @@ namespace ExCSS
                 case TokenType.Delim:
                     OnDelim(token);
                     break;
+                case TokenType.GreaterThan:
+                    OnDelim(token);
+                    break;
                 case TokenType.Comma:
                     InsertOr();
                     _ready = false;

--- a/src/ExCSS/Rules/ContainerRule.cs
+++ b/src/ExCSS/Rules/ContainerRule.cs
@@ -1,0 +1,32 @@
+﻿using System.IO;
+using System.Linq;
+
+namespace ExCSS
+{
+    internal sealed class ContainerRule : ConditionRule, IContainerRule
+    {
+        internal ContainerRule(StylesheetParser parser) : base(RuleType.Container, parser)
+        {
+            AppendChild(new MediaList(parser));
+        }
+
+        public override void ToCss(TextWriter writer, IStyleFormatter formatter)
+        {
+            var rules = formatter.Block(Rules);
+            var name = "@container";
+            if (!string.IsNullOrEmpty(Name))
+                name = $"{name} {Name}";
+            writer.Write(formatter.Rule(name, ConditionText, rules));
+        }
+
+        public MediaList Media => Children.OfType<MediaList>().FirstOrDefault();
+
+        public string Name { get; set; }
+
+        public string ConditionText
+        {
+            get => Media.MediaText;
+            set => Media.MediaText = value;
+        }
+    }
+}

--- a/src/ExCSS/Rules/IContainer.cs
+++ b/src/ExCSS/Rules/IContainer.cs
@@ -1,0 +1,8 @@
+﻿namespace ExCSS
+{
+    public interface IContainerRule : IConditionRule
+    {
+        string Name { get; set; }
+        MediaList Media { get; }
+  }
+}

--- a/src/ExCSS/StyleProperties/Container/ContainerNameProperty.cs
+++ b/src/ExCSS/StyleProperties/Container/ContainerNameProperty.cs
@@ -1,0 +1,15 @@
+﻿namespace ExCSS
+{
+    internal sealed class ContainerNameProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter =
+            Converters.StringConverter.OrDefault();
+
+        internal ContainerNameProperty()
+            : base(PropertyNames.ContainerName)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Container/ContainerTypeProperty.cs
+++ b/src/ExCSS/StyleProperties/Container/ContainerTypeProperty.cs
@@ -1,0 +1,15 @@
+﻿namespace ExCSS
+{
+    internal sealed class ContainerTypeProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter =
+            Converters.ContainerTypeConverter.OrDefault(Keywords.Normal);
+
+        internal ContainerTypeProperty()
+            : base(PropertyNames.ContainerType)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}


### PR DESCRIPTION
This PR adds support for @container queries as defined in CSS Containment Module Level 3. This PR also adds support for comparison operartors in media/container queries as defined in the spec for Media Queries Level 4.

Also added two new Properties (ContainerName and ContainerType).

I also added a new Test for Comparison operator in media queries and of course added tests for containers.