### PR TITLE
Fixed a bug when parsing a complex selector and there was no space after a ">".

### DIFF
--- a/src/ExCSS.Tests/Sheet.cs
+++ b/src/ExCSS.Tests/Sheet.cs
@@ -1265,5 +1265,21 @@ h1 {
         {
             var sheet = ParseStyleSheet(".style{ z-index: 99999999999999999;}");
         }
+
+        [Fact]
+        public void CanHandleGreaterThanSelectorWithNoFollowingSpace()
+        {
+            var sheet = ParseStyleSheet(@"#collapse-button >#icon{ }");
+            Assert.Equal(1, sheet.Rules.Length);
+            Assert.IsType<StyleRule>(sheet.Rules[0]);
+            var rule = sheet.Rules[0] as StyleRule;
+            Assert.IsType<ComplexSelector>(rule.Selector);
+            var selector = (ComplexSelector)rule.Selector;
+            
+            var parts = selector.ToList();
+            Assert.Equal(2, parts.Count());
+            Assert.IsType<IdSelector>(parts[0].Selector);
+            Assert.IsType<IdSelector>(parts[1].Selector);
+        }
     }
 }

--- a/src/ExCSS/Parser/Lexer.cs
+++ b/src/ExCSS/Parser/Lexer.cs
@@ -215,6 +215,7 @@ namespace ExCSS
                         Advance();
                         return NewGreaterThanOrEqual();
                     }
+                    GetPrevious();
                     return NewGreaterThan();
                 default:
                     return current.IsNameStart() ? IdentStart(current) : NewDelimiter(current);


### PR DESCRIPTION
Fixed a bug where the next selector can be incorrectly parsed if you parse a complex selector and it contains a ">" without a following space.
For example
```css
#collapse-button >#icon{ }
```

Would become and `IdSelecor` and a `TypeSelector` instead of 2 IdSelectors.
The bug was in the Lexer handling for `Symbols.GreaterThan`, it would `Advance` to perform a check for `Symbols.Equality` but it would not return `GetPrevious` if the value was not found. This PR includes a fix and a test.