### PR TITLE
Add IsTrimmable and IsAotCompatible project attributes

### DIFF
--- a/src/ExCSS/ExCSS.csproj
+++ b/src/ExCSS/ExCSS.csproj
@@ -31,6 +31,14 @@
 		-->
 	</PropertyGroup>
 
+	<!-- Trimming parameters -->
+	<PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+		<IsAotCompatible>true</IsAotCompatible>
+		<IsTrimmable>true</IsTrimmable>
+		<SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+	</PropertyGroup>
+
 	<PropertyGroup Condition="'$(TargetFramework)' != ''">
 		<LangVersion>9.0</LangVersion>
 	</PropertyGroup>

--- a/src/ExCSS/ExCSS.csproj
+++ b/src/ExCSS/ExCSS.csproj
@@ -33,10 +33,14 @@
 
 	<!-- Trimming parameters -->
 	<PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
-		<IsAotCompatible>true</IsAotCompatible>
 		<IsTrimmable>true</IsTrimmable>
 		<SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
 		<EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+	</PropertyGroup>
+	<!-- AOT parameters -->
+	<PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+		<IsAotCompatible>true</IsAotCompatible>
+		<EnableAotAnalyzer>true</EnableAotAnalyzer>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(TargetFramework)' != ''">

--- a/src/ExCSS/Extensions/PortableExtensions.cs
+++ b/src/ExCSS/Extensions/PortableExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 
@@ -13,7 +14,11 @@ namespace ExCSS
             return char.ConvertFromUtf32(utf32);
         }
 
-        public static PropertyInfo[] GetProperties(this Type type)
+        public static PropertyInfo[] GetProperties(
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.NonPublicProperties)]
+#endif
+            this Type type)
         {
             return type.GetRuntimeProperties().ToArray();
         }

--- a/src/ExCSS/Factories/AttributeSelectorFactory.cs
+++ b/src/ExCSS/Factories/AttributeSelectorFactory.cs
@@ -1,22 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace ExCSS
 {
     public sealed class AttributeSelectorFactory
     {
         private static readonly Lazy<AttributeSelectorFactory> Lazy = new(() => new AttributeSelectorFactory());
-
-        private readonly Dictionary<string, Type> _types = new()
-        {
-            { Combinators.Exactly, typeof(AttrMatchSelector) },
-            { Combinators.InList, typeof(AttrListSelector) },
-            { Combinators.InToken, typeof(AttrHyphenSelector) },
-            { Combinators.Begins, typeof(AttrBeginsSelector) },
-            { Combinators.Ends, typeof(AttrEndsSelector) },
-            { Combinators.InText, typeof(AttrContainsSelector) },
-            { Combinators.Unlike, typeof(AttrNotMatchSelector) },
-        };
 
         private AttributeSelectorFactory()
         {
@@ -34,11 +22,23 @@ namespace ExCSS
                 _ = AttributeSelectorFactory.FormMatch(prefix, match);
             }
 
-            return _types.TryGetValue(combinator, out var type)
-                ? (IAttrSelector)Activator.CreateInstance(type, name, value)
-                : new AttrAvailableSelector(name, value);
+            if (combinator == Combinators.Exactly)
+                return new AttrMatchSelector(name, value);
+            if (combinator == Combinators.InList)
+                return new AttrListSelector(name, value);
+            if (combinator == Combinators.InToken)
+                return new AttrHyphenSelector(name, value);
+            if (combinator == Combinators.Begins)
+                return new AttrBeginsSelector(name, value);
+            if (combinator == Combinators.Ends)
+                return new AttrEndsSelector(name, value);
+            if (combinator == Combinators.InText)
+                return new AttrContainsSelector(name, value);
+            if (combinator == Combinators.Unlike)
+                return new AttrNotMatchSelector(name, value);
+            return new AttrAvailableSelector(name, value);
         }
-        
+
         private static string FormFront(string prefix, string match)
         {
             return string.Concat(prefix, Combinators.Pipe, match);


### PR DESCRIPTION
These attributes should help finding potential incompatibilities with PublishTrimmed or PublishAot applications.

Specifically in my case I got this error (while having warnings as erros enabled):
```
ILC : Trim analysis error IL2067: ExCSS.AttributeSelectorFactory.Create(String,String,String,String): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicConstructors' in call to 'System.Activator.CreateInstance(Type,Object[])'. The parameter '#ILLink.Shared.TypeSystemProxy.ParameterIndex' of method 'System.Collections.Generic.Dictionary`2<String,Type>.TryGetValue(String,Type&)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
```

There are multiple ways to fix this issue, and it's possible to keep Activator.CreateInstance usage, or add lambda methods in the dictionary. But I though this method is simple enough to just use if-tree instead of dictionary