### PR TITLE
Fix unicode-range tokenization and serialization

### DIFF
--- a/src/ExCSS.Tests/FontFace.cs
+++ b/src/ExCSS.Tests/FontFace.cs
@@ -42,5 +42,21 @@
             Assert.Equal("", fontface.Variant);
             Assert.Equal("", fontface.Weight);
         }
+
+        [Theory]
+        [InlineData("U+41-5A")]
+        [InlineData("U+0-7F")]
+        [InlineData("U+4??")]
+        [InlineData("U+000041")]
+        [InlineData("U+0025-00FF, U+4??")]
+        public void FontFaceUnicodeRangeIsRetained(string range)
+        {
+            var src = "@font-face{font-family:'Open Sans';unicode-range:" + range + "}";
+            var sheet = ParseStyleSheet(src);
+            Assert.Equal(1, sheet.Rules.Length);
+            var fontface = (IFontFaceRule)sheet.Rules[0];
+
+            Assert.Equal(range, fontface.Range);
+        }
     }
 }

--- a/src/ExCSS.Tests/Tokenization.cs
+++ b/src/ExCSS.Tests/Tokenization.cs
@@ -53,6 +53,49 @@
             Assert.Equal(url, token.Data);
         }
 
+        [Theory]
+        // A start of fewer than six hex digits may still be followed by a '-<hex>' range end.
+        [InlineData("U+41-5A", "41", "5A")]
+        [InlineData("U+0-7F", "0", "7F")]
+        [InlineData("U+400-4FF", "400", "4FF")]
+        [InlineData("U+000041-00005A", "000041", "00005A")]
+        public void CssParserUnicodeRangeWithStartAndEnd(string source, string start, string end)
+        {
+            var tokenizer = new Lexer(new TextSource(source));
+            var token = tokenizer.Get();
+
+            var range = Assert.IsType<RangeToken>(token);
+            Assert.Equal(TokenType.Range, range.Type);
+            Assert.Equal(start, range.Start);
+            Assert.Equal(end, range.End);
+            Assert.Equal(TokenType.EndOfFile, tokenizer.Get().Type);
+        }
+
+        [Theory]
+        // The wildcard form is unchanged: '?' pads the value out to six digits.
+        [InlineData("U+4??", "400", "4FF")]
+        [InlineData("U+??????", "000000", "FFFFFF")]
+        [InlineData("U+41", "41", "41")]
+        public void CssParserUnicodeRangeSingleValueOrWildcard(string source, string start, string end)
+        {
+            var tokenizer = new Lexer(new TextSource(source));
+            var token = tokenizer.Get();
+
+            var range = Assert.IsType<RangeToken>(token);
+            Assert.Equal(start, range.Start);
+            Assert.Equal(end, range.End);
+            Assert.Equal(TokenType.EndOfFile, tokenizer.Get().Type);
+        }
+
+        [Fact]
+        public void CssParserUnicodeRangeSelectedRangeIsExpandedOnDemand()
+        {
+            var tokenizer = new Lexer(new TextSource("U+41-43"));
+            var range = Assert.IsType<RangeToken>(tokenizer.Get());
+
+            Assert.Equal(new[] {"A", "B", "C"}, range.SelectedRange);
+        }
+
         [Fact]
         public void LexerOnlyCarriageReturn()
         {

--- a/src/ExCSS/Model/ValueBuilder.cs
+++ b/src/ExCSS/Model/ValueBuilder.cs
@@ -59,6 +59,10 @@ namespace ExCSS
                 case TokenType.GreaterThanOrEqual:
                 case TokenType.LessThan:
                 case TokenType.LessThanOrEqual:
+                case TokenType.Range:
+                    // A U+... unicode-range value (an @font-face descriptor) is a sequence of Range tokens.
+                    // Without this they hit the default arm and mark the whole value invalid, so the
+                    // descriptor is dropped entirely under strict (non-tolerant) parsing.
                     Add(token);
                     break;
                 case TokenType.Comment:

--- a/src/ExCSS/Parser/Lexer.cs
+++ b/src/ExCSS/Parser/Lexer.cs
@@ -896,9 +896,18 @@ namespace ExCSS
                 current = GetNext();
             }
 
-            if (StringBuffer.Length != 6)
+            // Fewer than 6 hex digits may be followed by '?' wildcards - which pad the value out and are
+            // mutually exclusive with the start-end range form - OR, just like a full 6-digit start, by a
+            // '-<hex>' range end (e.g. U+41-5A). Only the wildcard form is handled here; a '-' falls
+            // through to the shared range handling below.
+            if (StringBuffer.Length != 6 && current == Symbols.QuestionMark)
             {
-                for (var i = 0; i < 6 - StringBuffer.Length; i++)
+                // The wildcard budget must be captured up front: appending to StringBuffer inside the loop
+                // would otherwise shrink a "6 - StringBuffer.Length" bound on every iteration, so only half
+                // the available wildcards were ever consumed (U+?????? stopped after three).
+                var wildcards = 6 - StringBuffer.Length;
+
+                for (var i = 0; i < wildcards; i++)
                 {
                     if (current != Symbols.QuestionMark)
                     {

--- a/src/ExCSS/Tokens/RangeToken.cs
+++ b/src/ExCSS/Tokens/RangeToken.cs
@@ -5,6 +5,9 @@ namespace ExCSS
 {
     internal sealed class RangeToken : Token
     {
+        private string[] _selectedRange;
+        private bool _selectedRangeComputed;
+
         private string[] GetRange()
         {
             var index = int.Parse(Start, NumberStyles.HexNumber);
@@ -32,7 +35,6 @@ namespace ExCSS
         {
             Start = range.Replace(Symbols.QuestionMark, '0');
             End = range.Replace(Symbols.QuestionMark, 'F');
-            SelectedRange = GetRange();
         }
 
         public RangeToken(string start, string end, TextPosition position)
@@ -40,12 +42,33 @@ namespace ExCSS
         {
             Start = start;
             End = end;
-            SelectedRange = GetRange();
+        }
+
+        // Data holds the range without its "U+" prefix, so serializing it bare would emit "41-5A" - not a
+        // valid <urange> and not what was authored.
+        public override string ToValue()
+        {
+            return string.Concat("U+", Data);
         }
 
         //public bool IsEmpty => (SelectedRange == null) || (SelectedRange.Length == 0);
         public string Start { get; }
         public string End { get; }
-        public string[] SelectedRange { get; }
+
+        // Computed on demand: a legal range such as U+0-10FFFF expands to over a million strings, which is
+        // far too much to materialize eagerly in a token constructor for a value nothing may ever read.
+        public string[] SelectedRange
+        {
+            get
+            {
+                if (!_selectedRangeComputed)
+                {
+                    _selectedRange = GetRange();
+                    _selectedRangeComputed = true;
+                }
+
+                return _selectedRange;
+            }
+        }
     }
 }


### PR DESCRIPTION
### Problem

`@font-face { unicode-range: … }` does not survive parsing. Four separate defects combine:

**1. A start of fewer than six hex digits can't have a range end.** `Lexer.UnicodeRange` returns immediately out of the wildcard branch, so it never reaches the `-<hex>` handling below it:

```csharp
if (StringBuffer.Length != 6)
{
    // ... consume '?' wildcards ...
    return NewRange(FlushBuffer());   // <-- always returns
}

if (current == Symbols.Minus) { /* range end - unreachable unless exactly 6 digits */ }
```

`U+41-5A` tokenized as just `U+41`, leaving `-5A` behind as stray tokens. Only the *wildcard* form is mutually exclusive with the start-end form ([CSS Syntax 3 §4.3.6](https://www.w3.org/TR/css-syntax-3/#consume-a-unicode-range-token)); a `-` should fall through.

**2. The wildcard padding loop consumes only half its wildcards.** The bound `6 - StringBuffer.Length` is re-evaluated each iteration while the body appends to that same buffer, so it shrinks as `i` grows and they meet in the middle. `U+??????` stopped after three `?`, leaving `???` unconsumed.

**3. `ValueBuilder` has no case for `TokenType.Range`,** so range tokens fall to the default arm, mark the whole value invalid, and the descriptor is dropped entirely under strict (non-tolerant) parsing — the default.

**4. `RangeToken` serializes without its `U+` prefix.** `Data` holds the bare range, so once a descriptor *is* retained it round-trips as `41-5A`, which is not a valid `<urange>`.

### Fix

One change each, plus making `RangeToken.SelectedRange` lazy — a legal `U+0-10FFFF` expands to over a million strings, which the constructor materialized eagerly whether or not anything ever read the property. (Nothing in the library reads it today.)

### Tests

13 tests. `Tokenization.cs` covers the lexer directly: start/end forms (`U+41-5A`, `U+0-7F`, `U+400-4FF`, `U+000041-00005A`), the wildcard and single-value forms (`U+4??`, `U+??????`, `U+41`), and on-demand `SelectedRange` expansion. `FontFace.cs` covers the descriptor end-to-end through `IFontFaceRule.Range`, including a comma-separated list.

10 of the 13 fail on `master`. The full suite (1263 existing tests) stays green, and all seven target frameworks build with no new warnings.
