### PR TITLE
Accept whitespace around the offset sign in :nth-child(An+B)

### DIFF
--- a/src/ExCSS.Tests/SelectorsTests.cs
+++ b/src/ExCSS.Tests/SelectorsTests.cs
@@ -89,6 +89,63 @@ public class SelectorsTests
         Assert.Equal(expectedCount, list.Count());
     }
 
+    [Theory]
+    // "Whitespace is permitted on either side of the + or - that separates the An and B parts when both
+    // are present" (CSS Syntax 3 6.1), which lists "3n + 1" among its valid examples. The sign then
+    // arrives as a standalone delim token rather than as part of a signed <number>.
+    [InlineData(":nth-child(10n + 1)", 10, 1)]
+    [InlineData(":nth-child(10n - 1)", 10, -1)]
+    [InlineData(":nth-child(2n + 0)", 2, 0)]
+    [InlineData(":nth-child(-2n + 3)", -2, 3)]
+    [InlineData(":nth-child( 10n  +  1 )", 10, 1)]
+    // The compact form has always worked and must keep working.
+    [InlineData(":nth-child(10n+1)", 10, 1)]
+    [InlineData(":nth-child(10n-1)", 10, -1)]
+    [InlineData(":nth-child(odd)", 2, 1)]
+    [InlineData(":nth-child(even)", 2, 0)]
+    public void NthChildAcceptsAnBWithAndWithoutSpaces(string selector, int step, int offset)
+    {
+        var sheet = new StylesheetParser().Parse(selector + " { color: red }");
+
+        Assert.Equal(1, sheet.Rules.Length);
+        var child = Assert.IsAssignableFrom<ChildSelector>(((StyleRule)sheet.Rules[0]).Selector);
+        Assert.Equal(step, child.Step);
+        Assert.Equal(offset, child.Offset);
+    }
+
+    [Theory]
+    [InlineData(":nth-last-child(3n + 2)", 3, 2)]
+    [InlineData(":nth-of-type(3n + 2)", 3, 2)]
+    [InlineData(":nth-last-of-type(3n + 2)", 3, 2)]
+    public void NthVariantsAcceptSpacedSign(string selector, int step, int offset)
+    {
+        var sheet = new StylesheetParser().Parse(selector + " { color: red }");
+
+        Assert.Equal(1, sheet.Rules.Length);
+        var child = Assert.IsAssignableFrom<ChildSelector>(((StyleRule)sheet.Rules[0]).Selector);
+        Assert.Equal(step, child.Step);
+        Assert.Equal(offset, child.Offset);
+    }
+
+    [Theory]
+    // The production requires a <signless-integer> after a standalone sign, so a second sign is invalid.
+    // CSS Syntax 3 6.1 lists "3n + -6" among its invalid examples.
+    [InlineData(":nth-child(3n + -6)")]
+    [InlineData(":nth-child(10n + -1)")]
+    [InlineData(":nth-child(10n + +1)")]
+    [InlineData(":nth-child(10n + + 1)")]
+    [InlineData(":nth-child(10n + n)")]
+    // 6.1's invalid whitespace examples: the An part and the leading sign may not be split.
+    [InlineData(":nth-child(3 n)")]
+    [InlineData(":nth-child(+ 2n)")]
+    [InlineData(":nth-child(+ 2)")]
+    public void NthChildRejectsMalformedSpacedOffset(string selector)
+    {
+        var sheet = new StylesheetParser().Parse(selector + " { color: red }");
+
+        Assert.Equal(0, sheet.Rules.Length);
+    }
+
     private static bool HasStandardPseudoElementSelector(ISelector selector, bool negate = false)
     {
         if (selector is PseudoElementSelector pes)

--- a/src/ExCSS/Parser/SelectorConstructor.cs
+++ b/src/ExCSS/Parser/SelectorConstructor.cs
@@ -803,6 +803,7 @@ namespace ExCSS
                     ParseState.Initial => OnInitial(token),
                     ParseState.AfterInitialSign => OnAfterInitialSign(token),
                     ParseState.Offset => OnOffset(token),
+                    ParseState.AfterOffsetSign => OnAfterOffsetSign(token),
                     ParseState.BeforeOf => OnBeforeOf(token),
                     _ => OnAfter(token)
                 };
@@ -879,8 +880,36 @@ namespace ExCSS
                         _offset *= _sign;
                         _state = ParseState.BeforeOf;
                         return false;
+                    case TokenType.Delim when token.Data.IsOneOf("+", "-"):
+                        // When whitespace separates the offset's sign from its digits the sign arrives as a
+                        // standalone delim token - the "<n-dimension> ['+' | '-'] <signless-integer>"
+                        // production of <a-n-plus-b> (CSS Syntax 3 6.2). The compact form "10n+1" instead
+                        // lexes as one signed <number> and is handled by the Number case above.
+                        _sign = token.Data == "-" ? -1 : +1;
+                        _state = ParseState.AfterOffsetSign;
+                        return false;
                     default:
                         return OnBeforeOf(token);
+                }
+            }
+
+            private bool OnAfterOffsetSign(Token token)
+            {
+                switch (token.Type)
+                {
+                    case TokenType.Whitespace:
+                        return false;
+                    case TokenType.Number when !token.Data.StartsWith("+") && !token.Data.StartsWith("-"):
+                        // The production requires a <signless-integer> here, defined as "a <number-token>
+                        // with its type flag set to integer, and no sign character" (CSS Syntax 3 6.2), so
+                        // "10n + -1" and "10n + +1" are invalid - 6.1 lists "3n + -6" as an invalid example.
+                        _valid = _valid && ((NumberToken) token).IsInteger && int.TryParse(token.Data, out _offset);
+                        _offset *= _sign;
+                        _state = ParseState.BeforeOf;
+                        return false;
+                    default:
+                        _valid = false;
+                        return token.Type == TokenType.RoundBracketClose;
                 }
             }
 
@@ -918,6 +947,7 @@ namespace ExCSS
                 Initial,
                 AfterInitialSign,
                 Offset,
+                AfterOffsetSign,
                 BeforeOf,
                 AfterOf
             }


### PR DESCRIPTION
### Problem

```css
:nth-child(10n + 1)   /* rejected */
:nth-child(10n+1)     /* accepted */
```

[CSS Syntax 3 §6.2](https://www.w3.org/TR/css-syntax-3/#the-anb-type) defines `<a-n-plus-b>` with, among others, the production:

> `<n-dimension> ['+' | '-'] <signless-integer>`

and [§6.1](https://www.w3.org/TR/css-syntax-3/#anb-syntax-description) states:

> Whitespace is permitted on either side of the `+` or `-` that separates the `An` and `B` parts when both are present.

listing `3n + 1`, `+3n - 2` and `-n+ 6` as valid examples.

The two spellings lex differently:

| Source | Tokens after `10n` |
| --- | --- |
| `10n+1` | one signed `<number>` `+1` |
| `10n + 1` | `<whitespace>`, `<delim +>`, `<whitespace>`, `<number>` `1` |

`ChildFunctionState.OnOffset` handles only `Whitespace` and `Number`, so the standalone delim falls through its `default:` arm into `OnBeforeOf` — which is looking for `of` or `)` — and sets `_valid = false`, dropping the rule.

This affects `:nth-child()`, `:nth-last-child()`, `:nth-of-type()` and `:nth-last-of-type()` alike.

### Fix

Handle the `+`/`-` delim in `OnOffset` and add an `AfterOffsetSign` state for the digits that follow.

That state is deliberately strict rather than just setting a sign flag and staying put, because the production calls for a **`<signless-integer>`**, which §6.2 defines as:

> a `<number-token>` with its type flag set to "integer", and no sign character

So a second sign stays invalid — and §6.1 lists **`3n + -6`** among its invalid examples, which is exactly this case. `NumberToken.Data` preserves the authored sign character, which is what the check keys on.

### Tests

20 theory cases in `SelectorsTests.cs`, asserting `ChildSelector.Step`/`Offset` rather than round-tripped text:

- spaced forms — `10n + 1`, `10n - 1`, `2n + 0`, `-2n + 3`, and extra internal whitespace
- compact forms and `odd`/`even`, which must keep working unchanged
- the three other `:nth-*` variants
- the spec's own invalid examples — `3n + -6`, `3 n`, `+ 2n`, `+ 2` — plus `10n + +1`, `10n + + 1` and `10n + n`

8 fail on `master`; the invalid cases pass both before and after, confirming the fix doesn't loosen the grammar. The full suite (1263 existing tests) stays green with no existing assertion modified, and all seven target frameworks build with no new warnings.
