### PR TITLE
Discard a bare semicolon inside a block's contents

### DIFF
--- a/src/ExCSS.Tests/Sheet.cs
+++ b/src/ExCSS.Tests/Sheet.cs
@@ -222,6 +222,73 @@ h1 {
         }
 
         [Fact]
+        public void CssSheetBareSemicolonInsideBlockIsDiscarded()
+        {
+            // "Consume a block's contents" discards a <semicolon-token> just like whitespace
+            // (CSS Syntax 3 5.5.5), so a stray ';' inside a grouping rule must not disturb the block or
+            // anything after it.
+            var sheet = ParseStyleSheet(@"
+            @media screen {
+                .a { color: red; }
+                ;
+                .b { color: blue; }
+            }");
+            Assert.Equal(1, sheet.Rules.Length);
+            var media = (MediaRule)sheet.Rules[0];
+            Assert.Equal(2, media.Rules.Length);
+            Assert.Equal(".a", ((StyleRule)media.Rules[0]).SelectorText);
+            Assert.Equal(".b", ((StyleRule)media.Rules[1]).SelectorText);
+        }
+
+        [Fact]
+        public void CssSheetBareSemicolonInsideBlockDoesNotSwallowFollowingRule()
+        {
+            // The trailing ';' used to be folded into a run-on selector that consumed the block's closing
+            // brace, taking the *next* top-level rule with it.
+            var sheet = ParseStyleSheet(@"
+            @media screen { .a { color: red; } ; }
+            @media print { .b { color: blue; } }");
+            Assert.Equal(2, sheet.Rules.Length);
+            Assert.Equal(RuleType.Media, sheet.Rules[0].Type);
+            Assert.Equal(RuleType.Media, sheet.Rules[1].Type);
+        }
+
+        [Fact]
+        public void CssSheetMultipleBareSemicolonsInsideBlockAreDiscarded()
+        {
+            var sheet = ParseStyleSheet(@"@media screen { ;;.a { color: red; };; }");
+            Assert.Equal(1, sheet.Rules.Length);
+            var media = (MediaRule)sheet.Rules[0];
+            Assert.Equal(1, media.Rules.Length);
+            Assert.Equal(".a", ((StyleRule)media.Rules[0]).SelectorText);
+        }
+
+        [Fact]
+        public void CssSheetBareSemicolonInsideSupportsBlockIsDiscarded()
+        {
+            var sheet = ParseStyleSheet(@"@supports (color: red) { ; .a { color: red; } }");
+            Assert.Equal(1, sheet.Rules.Length);
+            var supports = (SupportsRule)sheet.Rules[0];
+            Assert.Equal(1, supports.Rules.Length);
+        }
+
+        [Fact]
+        public void CssSheetBareTopLevelSemicolonInvalidatesTheFollowingRule()
+        {
+            // Deliberately asymmetric with the block case above. "Consume a stylesheet's contents"
+            // (CSS Syntax 3 5.5.1) has no <semicolon-token> case, so a stray top-level ';' falls to
+            // "anything else" and is consumed into the next qualified rule's prelude by 5.5.3, leaving an
+            // invalid selector. Only a block passes <semicolon-token> as that algorithm's stop token.
+            //
+            // The Acid2 parser-torture block depends on this: its ".parser { m\argin: 2em; };" is followed
+            // by ".parser { height: 3em; }", which must NOT apply - one of a run of deliberately-dropped
+            // rules alongside "width: 200" and "border: 5em solid red ! error".
+            var sheet = ParseStyleSheet(@".a { color: red; } ; .b { color: blue; }");
+            Assert.Equal(1, sheet.Rules.Length);
+            Assert.Equal(".a", ((StyleRule)sheet.Rules[0]).SelectorText);
+        }
+
+        [Fact]
         public void CssSheetInvalidStatementRulesetUnexpectedRightParenthesis()
         {
             var sheet = ParseStyleSheet(@") ( {} ) p {color: red }");
@@ -964,8 +1031,12 @@ p.info span::after {
         background: #FFF;
     }
 }");
-            Assert.Equal(1, sheet.Rules.Length);
+            // Two @media rules in, two out. The stray ';' inside the first block is discarded by "consume a
+            // block's contents" (CSS Syntax 3 5.5.5); it previously ran on through the block's closing brace
+            // and swallowed the second rule, which is what the old expectation of 1 recorded.
+            Assert.Equal(2, sheet.Rules.Length);
             Assert.Equal(RuleType.Media, sheet.Rules[0].Type);
+            Assert.Equal(RuleType.Media, sheet.Rules[1].Type);
         }
 
         [Fact]

--- a/src/ExCSS/Parser/StylesheetComposer.cs
+++ b/src/ExCSS/Parser/StylesheetComposer.cs
@@ -1068,6 +1068,24 @@ namespace ExCSS
 
             while (token.IsNot(TokenType.EndOfFile, TokenType.CurlyBracketClose))
             {
+                // "Consume a block's contents" discards a <semicolon-token> outright, exactly as it does a
+                // <whitespace-token> (CSS Syntax 3 5.5.5). Passing it on to CreateStyle instead feeds it to
+                // SelectorConstructor, which has no recovery for an unexpected semicolon: it folds the token
+                // into the next rule's selector and invalidates it, and because the run-on rule then keeps
+                // consuming, the block's own closing brace is swallowed too and the following sibling rule
+                // is lost with it.
+                //
+                // Note this is deliberately NOT done in CreateRules: "consume a stylesheet's contents"
+                // (5.5.1) has no <semicolon-token> case, so a stray semicolon there falls to "anything else"
+                // and is consumed into the next qualified rule's prelude, invalidating it. Only a block
+                // passes <semicolon-token> as the stop token to "consume a qualified rule" (5.5.3).
+                if (token.Type == TokenType.Semicolon)
+                {
+                    token = NextToken();
+                    ParseComments(ref token);
+                    continue;
+                }
+
                 var rule = CreateRule(token);
                 token = NextToken();
                 ParseComments(ref token);


### PR DESCRIPTION
> **Rewritten.** The first version of this PR fixed the *top-level* case and deliberately left blocks alone. Having now read [CSS Syntax Module Level 3](https://www.w3.org/TR/css-syntax-3/) properly, that was backwards — the spec says the opposite. Details under "Why the top level is excluded" below.

### Problem

A bare `;` inside a grouping rule's block invalidates the next rule *and* swallows the block's closing brace, taking the following sibling rule with it:

```css
@media screen { .a { color: red; } ; }
@media print  { .b { color: blue; } }   /* silently disappears */
```

`FillRules` hands the semicolon to `CreateRule` → `CreateStyle` → `SelectorConstructor`, which has no recovery for an unexpected semicolon. It folds the token into the next rule's selector and invalidates it; the run-on rule then keeps consuming past the block's `}`.

### What the spec says

[§5.5.5 "Consume a block's contents"](https://drafts.csswg.org/css-syntax-3/#consume-block-contents) lists `<semicolon-token>` together with `<whitespace-token>`:

> `<whitespace-token>`
> `<semicolon-token>`
>   Discard a token from input.

So inside a block a stray semicolon is simply thrown away, exactly like whitespace.

### Fix

Discard the token in `FillRules`, which is ExCSS's implementation of that algorithm (it backs `@media`, `@supports` and `@container`).

### Why the top level is excluded

The asymmetry is intentional and is the part I originally got wrong.

[§5.5.1 "Consume a stylesheet's contents"](https://drafts.csswg.org/css-syntax-3/#consume-stylesheet-contents) has cases for `<whitespace-token>`, `<EOF-token>`, `<CDO-token>`/`<CDC-token>` and `<at-keyword-token>`, then "anything else → Consume a qualified rule". There is **no** `<semicolon-token>` case, so a top-level `;` falls into "anything else".

[§5.5.3 "Consume a qualified rule"](https://drafts.csswg.org/css-syntax-3/#consume-qualified-rule) only treats a semicolon specially when it is the **stop token**, and a stop token is passed in exactly one place — from §5.5.5, `"consume a qualified rule from input, with nested set to true, and <semicolon-token> as the stop token"`. At the top level none is passed, so the `;` is consumed as a component value into the prelude, leaving an invalid selector and an invalid rule.

That is what ExCSS already does, so the top level is left untouched. A test now pins it so it doesn't get "fixed" by mistake later.

Acid2 agrees, and I had it backwards the first time round. Its parser-torture block is a run of deliberately-dropped rules, and the trailing `;` is the mechanism for one of them:

```css
.parser { m\argin: 2em; };
.parser { height: 3em; }        /* must NOT apply */
.parser { width: 200; }         /* must NOT apply - no unit */
.parser { border: 5em solid red ! error; }   /* must NOT apply */
```

### One existing assertion changed

`CssParseSheetWithAtAndCommentDoesNotTakeForever3` is exactly the swallowing case above. Its source contains two `@media` rules and it asserted `Assert.Equal(1, sheet.Rules.Length)` — the count the old behaviour produced. The spec-correct count is 2, so the assertion is updated and the second rule's type is now asserted too. The `[Fact(Timeout = 1000)]` guard the test exists for is untouched.

This is the only pre-existing assertion this PR (or any of my others) modifies. Flagging it explicitly since it is a behaviour change, not just an addition.

### Tests

5 new tests in `Sheet.cs`: a semicolon between rules in a block, the swallowed-sibling case, repeated semicolons, `@supports` as well as `@media`, and the top-level case asserting the spec-correct *invalidating* behaviour.

Against `master`, the 4 block tests fail plus the updated one; the top-level test passes on `master` unchanged, confirming it documents existing behaviour. The other 1262 existing tests stay green, and all seven target frameworks build with no new warnings.
