### PR TITLE
Fix swapped larger/smaller entries in Map.FontSizes

### DIFF
--- a/src/ExCSS.Tests/FontProperty.cs
+++ b/src/ExCSS.Tests/FontProperty.cs
@@ -831,5 +831,33 @@
             //Assert.Equal("georgia", concrete.Families.First());
             //Assert.Equal("Times New Roman", concrete.Families.Skip(1).First());
         }
+
+        [Theory]
+        // The relative font-size keywords must map to the matching FontSize members: 'larger' scales up
+        // (120%) and 'smaller' scales down (80%), per CSS 2.1 15.7 / CSS Fonts 3 3.5.
+        [InlineData("larger", FontSize.Larger, 120f)]
+        [InlineData("smaller", FontSize.Smaller, 80f)]
+        public void CssFontSizeRelativeKeywordMapsToMatchingSize(string keyword, FontSize expected,
+            float expectedPercent)
+        {
+            Assert.Equal(expected, Map.FontSizes[keyword]);
+
+            var length = Map.FontSizes[keyword].ToLength();
+            Assert.Equal(Length.Unit.Percent, length.Type);
+            Assert.Equal(expectedPercent, length.Value);
+        }
+
+        [Theory]
+        [InlineData("larger")]
+        [InlineData("smaller")]
+        public void CssFontSizeRelativeKeywordLegal(string keyword)
+        {
+            var property = ParseDeclaration("font-size: " + keyword);
+            Assert.Equal("font-size", property.Name);
+            Assert.IsType<FontSizeProperty>(property);
+            var concrete = (FontSizeProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Equal(keyword, concrete.Value);
+        }
     }
 }

--- a/src/ExCSS/Model/Map.cs
+++ b/src/ExCSS/Model/Map.cs
@@ -198,8 +198,8 @@ namespace ExCSS
                 {Keywords.Large, FontSize.Large},
                 {Keywords.XLarge, FontSize.Big},
                 {Keywords.XxLarge, FontSize.Huge},
-                {Keywords.Larger, FontSize.Smaller},
-                {Keywords.Smaller, FontSize.Larger}
+                {Keywords.Larger, FontSize.Larger},
+                {Keywords.Smaller, FontSize.Smaller}
             };
         public static readonly Dictionary<string, TextDecorationStyle> TextDecorationStyles =
             new(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
### Problem

`Map.FontSizes` has the two relative keywords crossed:

```csharp
{Keywords.Larger, FontSize.Smaller},
{Keywords.Smaller, FontSize.Larger}
```

`ValueExtensions.ToLength` resolves `FontSize.Larger` to `120%` and `FontSize.Smaller` to `80%`, so `larger` resolves to the shrink factor and `smaller` to the grow factor — the opposite of [CSS 2.1 §15.7](https://www.w3.org/TR/CSS21/fonts.html#font-boldness) / [CSS Fonts 3 §3.5](https://www.w3.org/TR/css-fonts-3/#font-size-prop).

### Scope

The defect is **latent today**. `DictionaryValueConverter` looks the identifier up with `TryGetValue(identifier, out _)` and keeps only the key, discarding the mapped `FontSize` entirely, and `Map.FontSizes` has no other consumer. So nothing currently reads these values — but the table is wrong, and it becomes live the moment anything does.

Because of that, the fix is not observable through the property API. The tests therefore assert the mapping directly (the test assembly already has `InternalsVisibleTo`), which is what actually pins the intent:

```csharp
Assert.Equal(FontSize.Larger, Map.FontSizes["larger"]);

var length = Map.FontSizes["larger"].ToLength();
Assert.Equal(Length.Unit.Percent, length.Type);
Assert.Equal(120f, length.Value);
```

Plus two round-trip tests confirming both keywords still parse as `font-size` values, so the table change doesn't disturb the converter path.

2 of the 4 fail on `master`. The full suite (1263 existing tests) stays green, and all seven target frameworks build with no new warnings.
