### PR TITLE
Reject non-numeric input in Length.TryParse

### DIFF
--- a/src/ExCSS.Tests/LengthTests.cs
+++ b/src/ExCSS.Tests/LengthTests.cs
@@ -1,0 +1,54 @@
+namespace ExCSS.Tests
+{
+    using ExCSS;
+    using Xunit;
+
+    public class LengthTests
+    {
+        [Theory]
+        [InlineData("10px", 10f, Length.Unit.Px)]
+        [InlineData("1.5em", 1.5f, Length.Unit.Em)]
+        [InlineData("-3pt", -3f, Length.Unit.Pt)]
+        [InlineData("50%", 50f, Length.Unit.Percent)]
+        [InlineData("2.5rem", 2.5f, Length.Unit.Rem)]
+        [InlineData("0px", 0f, Length.Unit.Px)]
+        public void LengthTryParseAcceptsValueWithUnit(string source, float value, Length.Unit unit)
+        {
+            Assert.True(Length.TryParse(source, out var result));
+            Assert.Equal(value, result.Value);
+            Assert.Equal(unit, result.Type);
+        }
+
+        [Theory]
+        // A zero length may omit its unit (CSS Values 3 5.2).
+        [InlineData("0")]
+        [InlineData("0.0")]
+        [InlineData("-0")]
+        public void LengthTryParseAcceptsUnitlessZero(string source)
+        {
+            Assert.True(Length.TryParse(source, out var result));
+            Assert.Equal(0f, result.Value);
+            Assert.Equal(Length.Unit.Px, result.Type);
+        }
+
+        [Theory]
+        // Input that isn't a number at all must be rejected rather than silently becoming zero.
+        [InlineData("")]
+        [InlineData("auto")]
+        [InlineData("inherit")]
+        [InlineData("red")]
+        [InlineData("px")]
+        [InlineData("%")]
+        [InlineData("garbage")]
+        // A non-zero number still requires a unit.
+        [InlineData("5")]
+        [InlineData("-2.5")]
+        // An unrecognised unit is not a length.
+        [InlineData("10foo")]
+        public void LengthTryParseRejectsNonLength(string source)
+        {
+            Assert.False(Length.TryParse(source, out var result));
+            Assert.Equal(default, result);
+        }
+    }
+}

--- a/src/ExCSS/Values/Length.cs
+++ b/src/ExCSS/Values/Length.cs
@@ -176,7 +176,11 @@ namespace ExCSS
                 return true;
             }
 
-            if (value == 0f)
+            // Only a genuinely parsed unitless "0" may omit its unit (CSS Values 3 5.2). StylesheetUnit
+            // returns an empty unit string for a plain number but null when it could not tokenize a number
+            // at all, and both leave value at 0 - so the unit string has to be checked as well, otherwise
+            // arbitrary non-length input is accepted as zero.
+            if (unitString != null && unitString.Length == 0 && value == 0f)
             {
                 result = Zero;
                 return true;


### PR DESCRIPTION
### Problem

`Length.TryParse` reports success for input that is not a length at all:

```csharp
Length.TryParse("auto", out var r);   // true, r == 0px
Length.TryParse("red", out var r);    // true, r == 0px
Length.TryParse("", out var r);       // true, r == 0px
Length.TryParse("garbage", out var r) // true, r == 0px
```

The zero fallback exists for a good reason — [CSS Values 3 §5.2](https://www.w3.org/TR/css-values-3/#lengths) allows a zero length to omit its unit — but it keys only on the value:

```csharp
var unitString = s.StylesheetUnit(out var value);
var unit = GetUnit(unitString);

if (unit != Unit.None) { result = new Length(value, unit); return true; }

if (value == 0f) { result = Zero; return true; }   // <-- also matches "auto", "red", ""
```

`StringExtensions.StylesheetUnit` sets `result = default` (0) both when it parses a unitless zero **and** when it can't find a number at all, so the two are indistinguishable by value alone.

### Fix

They *are* distinguishable by the returned unit string — empty for a plain number, `null` when nothing could be tokenized — so check that too.

`Angle`, `Frequency` and `Resolution` have no equivalent fallback (they require a recognised unit), so this is specific to `Length`.

### Tests

New `LengthTests.cs`, 19 theory cases:

- values with units, including `0px` and negatives
- unitless zero in its accepted forms — `0`, `0.0`, `-0`
- non-length input that must now be rejected — `""`, `auto`, `inherit`, `red`, `px`, `%`, `garbage`
- a non-zero number without a unit (`5`, `-2.5`) and an unrecognised unit (`10foo`)

7 fail on `master`. The full suite (1263 existing tests) stays green, and all seven target frameworks build with no new warnings.
