### PR TITLE
Return null from StartsWithValueConverter on empty input

### DIFF
--- a/src/ExCSS.Tests/Property.cs
+++ b/src/ExCSS.Tests/Property.cs
@@ -1304,5 +1304,40 @@
             Assert.Equal("my-Property", property.Name);
             Assert.IsType<UnknownProperty>(property);
         }
+
+        [Fact]
+        public void StartsWithConverterOnEmptyInputReturnsNull()
+        {
+            // ConvertDefault() feeds an empty token sequence, and VaryStart falls back to it once the token
+            // list is exhausted. Every other converter answers "no match"; this one dereferenced the
+            // exhausted enumerator's Current.
+            var converter = Converters.IntegerConverter.StartsWithDelimiter();
+
+            Assert.Null(converter.ConvertDefault());
+        }
+
+        [Fact]
+        public void StartsWithConverterOnWhitespaceOnlyInputReturnsNull()
+        {
+            var converter = Converters.IntegerConverter.StartsWithDelimiter();
+
+            Assert.Null(converter.Convert(new[] {Token.Whitespace, Token.Whitespace}));
+        }
+
+        [Theory]
+        // RatioConverter is the one composition that puts StartsWithDelimiter behind an ordered converter
+        // (WithOrder(IntegerConverter.Required(), IntegerConverter.StartsWithDelimiter().Required())), so
+        // these guard the nearest real-world path to the empty-input branch. They pass either way today -
+        // the ordered converter happens to reject the incomplete ratio before falling back to
+        // ConvertDefault - and exist to keep it that way.
+        [InlineData("@media (aspect-ratio: 16) { p { color: red } }")]
+        [InlineData("@media (device-aspect-ratio: 16) { p { color: red } }")]
+        [InlineData("@media (min-aspect-ratio: 16) { p { color: red } }")]
+        public void IncompleteRatioMediaFeatureDoesNotThrow(string source)
+        {
+            var sheet = ParseStyleSheet(source);
+
+            Assert.Equal(1, sheet.Rules.Length);
+        }
     }
 }

--- a/src/ExCSS/ValueConverters/StartsWithValueConverter.cs
+++ b/src/ExCSS/ValueConverters/StartsWithValueConverter.cs
@@ -37,10 +37,16 @@ namespace ExCSS
         {
             using var enumerator = values.GetEnumerator();
 
-            while (enumerator.MoveNext() && enumerator.Current.Type == TokenType.Whitespace)
+            bool hasCurrent;
+
+            while ((hasCurrent = enumerator.MoveNext()) && enumerator.Current.Type == TokenType.Whitespace)
             {
                 //Empty on purpose.
             }
+
+            // Empty (or whitespace-only) input - which ConvertDefault supplies, and VaryStart falls back to -
+            // must resolve to "no match" rather than dereferencing an exhausted enumerator's Current.
+            if (!hasCurrent) return null;
 
             if (enumerator.Current.Type != _type || !enumerator.Current.Data.Isi(_data)) return null;
             var list = new List<Token>();


### PR DESCRIPTION
### Problem

`StartsWithValueConverter.Transform` skips leading whitespace and then reads `Current` without checking whether the enumerator was exhausted:

```csharp
while (enumerator.MoveNext() && enumerator.Current.Type == TokenType.Whitespace)
{
    //Empty on purpose.
}

if (enumerator.Current.Type != _type || ...) return null;   // <-- enumerator may be finished
```

When the sequence is empty or whitespace-only, the loop exits because `MoveNext()` returned `false`, and `Current` is then either `null` or throws depending on the enumerator implementation:

```csharp
Converters.IntegerConverter.StartsWithDelimiter().ConvertDefault();
// System.NullReferenceException

converter.Convert(new[] { Token.Whitespace });
// System.InvalidOperationException: Enumeration already finished.
```

Empty input isn't an exotic case here: `ConvertDefault()` passes `Enumerable.Empty<Token>()` by definition, and `VaryStart` falls back to `ConvertDefault()` once its token list is exhausted. Every other converter treats empty input as "no match" — `DictionaryValueConverter`, for instance, gets `null` back from `ToIdentifier()` and returns `null`.

### Fix

Capture the `MoveNext()` result and return `null` when the sequence was exhausted.

This also unblocks composing `StartsWithValueConverter` into converters that get probed with empty input — for example a `font-style: oblique <angle>` converter, which is where I hit it.

### Tests

5 tests in `Property.cs`:

- `ConvertDefault()` on a `StartsWithDelimiter` converter returns null (currently `NullReferenceException`)
- whitespace-only input returns null (currently `InvalidOperationException`)
- 3 guards over `RatioConverter` — the one composition that puts `StartsWithDelimiter` behind an ordered converter — parsing incomplete `aspect-ratio` media features

The first 2 fail on `master`; the 3 guards pass either way and are there to keep the real-world path covered. The full suite (1263 existing tests) stays green, and all seven target frameworks build with no new warnings.
