### PR TITLE
Keep layers comma-separated when exporting a multi-layer shorthand

### DIFF
--- a/src/ExCSS.Tests/PropertyTests/BackgroundProperty.cs
+++ b/src/ExCSS.Tests/PropertyTests/BackgroundProperty.cs
@@ -736,5 +736,26 @@
             Assert.True(concrete.HasValue);
             Assert.Equal("url(\"" + url + "\")", concrete.Value);
         }
+
+        [Fact]
+        public void BackgroundMultipleLayersExportCommaSeparatedLonghands()
+        {
+            // Each comma-separated layer must stay its own layer when the shorthand is exported to the
+            // longhands; joining them with whitespace produces one invalid layer instead of two valid ones.
+            var style = ParseDeclarations("background: url(a.png) no-repeat, url(b.png) repeat");
+
+            Assert.Equal("url(\"a.png\"), url(\"b.png\")", style.BackgroundImage);
+            Assert.Equal("no-repeat, repeat", style.BackgroundRepeat);
+        }
+
+        [Fact]
+        public void BackgroundThreeLayersExportCommaSeparatedLonghands()
+        {
+            var style = ParseDeclarations(
+                "background: url(a.png) no-repeat, url(b.png) repeat-x, url(c.png) repeat");
+
+            Assert.Equal("url(\"a.png\"), url(\"b.png\"), url(\"c.png\")", style.BackgroundImage);
+            Assert.Equal("no-repeat, repeat-x, repeat", style.BackgroundRepeat);
+        }
     }
 }

--- a/src/ExCSS/ValueConverters/EndListValueConverter.cs
+++ b/src/ExCSS/ValueConverters/EndListValueConverter.cs
@@ -92,7 +92,11 @@ namespace ExCSS
 
                     if (extracted == null) continue;
 
-                    if (tokens.Count > 0) tokens.Add(Token.Whitespace);
+                    // Layers stay comma-separated when exported to a longhand, matching CssText above and
+                    // ListValueConverter's own ExtractFor. Joining with whitespace instead ran the layers
+                    // together: "background: url(a) no-repeat, url(b) repeat" gave a background-repeat of
+                    // "no-repeat repeat", which is a single invalid layer rather than two valid ones.
+                    if (tokens.Count > 0) tokens.Add(Token.Comma);
 
                     tokens.AddRange(extracted);
                 }


### PR DESCRIPTION
### Problem

`EndListValueConverter.ListValue.ExtractFor` joins the per-layer values with whitespace:

```csharp
if (tokens.Count > 0) tokens.Add(Token.Whitespace);
```

but its own `CssText` joins with `", "`, and `ListValueConverter.ExtractFor` — the sibling that handles plain comma lists — uses `Token.Comma`. `EndListValueConverter` is the one behind `background`, where a final layer may additionally carry `background-color`.

The result is that exporting a multi-layer shorthand to its longhands runs the layers together into a single invalid value:

```css
background: url(a.png) no-repeat, url(b.png) repeat
```

| longhand | before | after |
| --- | --- | --- |
| `background-repeat` | `no-repeat repeat` | `no-repeat, repeat` |
| `background-image` | `initial` | `url("a.png"), url("b.png")` |

`background-repeat` becomes one invalid two-keyword layer rather than two valid ones. `background-image` is worse: the whitespace-joined `url("a.png") url("b.png")` doesn't convert at all, so the longhand ends up with no value and reports `initial`.

Each comma-separated layer is its own layer for every longhand the shorthand covers ([CSS Backgrounds 3 §2.1](https://www.w3.org/TR/css-backgrounds-3/#layering)).

### Fix

Use `Token.Comma`, matching `ListValueConverter`.

### Tests

2 tests in `PropertyTests/BackgroundProperty.cs`, covering two- and three-layer backgrounds and asserting both `background-image` and `background-repeat`. Both fail on `master`.

The full suite (1263 existing tests) stays green with no existing assertion modified, and all seven target frameworks build with no new warnings.
