### PR TITLE
Keep @page declarations that follow a margin box

### DIFF
--- a/src/ExCSS.Tests/Cases.cs
+++ b/src/ExCSS.Tests/Cases.cs
@@ -912,6 +912,47 @@ tobi loki jane {
     }
 
     [Fact]
+    public void StyleSheetPageDeclarationAfterMarginBoxIsKept()
+    {
+        // A margin box's inner declaration block is consumed through its own closing '}', but the @page
+        // loop used to re-enter on a stale token afterwards and drop everything that followed. A
+        // declaration placed after the margin box must still be applied.
+        var sheet = ParseSheet("@page { @top-center { content: \"h\"; } margin: 1cm; }");
+        var pageRule = (PageRule)sheet.Rules[0];
+
+        Assert.Single(pageRule.Margins);
+        Assert.Equal("@top-center", pageRule.Margins.First().SelectorText);
+        Assert.Equal("1cm", pageRule.Style.MarginTop);
+        Assert.Equal("1cm", pageRule.Style.MarginRight);
+        Assert.Equal("1cm", pageRule.Style.MarginBottom);
+        Assert.Equal("1cm", pageRule.Style.MarginLeft);
+    }
+
+    [Fact]
+    public void StyleSheetPageDeclarationsBeforeAndAfterMarginBoxAreKept()
+    {
+        var sheet = ParseSheet("@page { color: red; @top-center { content: \"h\"; } margin: 1cm; }");
+        var pageRule = (PageRule)sheet.Rules[0];
+
+        Assert.Single(pageRule.Margins);
+        Assert.Equal("rgb(255, 0, 0)", pageRule.Style.Color);
+        Assert.Equal("1cm", pageRule.Style.MarginTop);
+    }
+
+    [Fact]
+    public void StyleSheetPageMultipleMarginBoxesThenDeclaration()
+    {
+        var sheet = ParseSheet(
+            "@page { @top-left { content: \"a\"; } @bottom-right { content: \"b\"; } margin: 2cm; }");
+        var pageRule = (PageRule)sheet.Rules[0];
+
+        Assert.Equal(2, pageRule.Margins.Count());
+        Assert.Equal("@top-left", pageRule.Margins.First().SelectorText);
+        Assert.Equal("@bottom-right", pageRule.Margins.Last().SelectorText);
+        Assert.Equal("2cm", pageRule.Style.MarginTop);
+    }
+
+    [Fact]
     public void StyleSheetProps()
     {
         var sheet = ParseSheet(@"

--- a/src/ExCSS/Parser/StylesheetComposer.cs
+++ b/src/ExCSS/Parser/StylesheetComposer.cs
@@ -605,7 +605,11 @@ namespace ExCSS
                         var marginToken = new Token(TokenType.Ident, token.Data, token.Position);
                         var marginStyle = CreateMarginStyle(ref marginToken);
                         parentPageRule.AppendChild(marginStyle);
-                        token = marginToken;
+                        // CreateMarginStyle's inner FillDeclarations consumed through the margin box's
+                        // closing '}' but left marginToken at the box's own '{'. Reusing it here re-enters
+                        // the loop on a stale token, so any declaration after the margin box (and any
+                        // further margin box) was dropped. Advance to the next real token instead.
+                        token = NextToken();
                     }
                     else
                     {


### PR DESCRIPTION
### Problem

Inside `@page`, any declaration that comes **after** a margin box is silently dropped:

```css
@page { @top-center { content: "h" } margin: 1cm }   /* margin: 1cm lost */
@page { @top-left {…} @bottom-right {…} margin: 2cm }  /* margin: 2cm lost */
```

A margin box (`@top-center`, `@bottom-right`, …, per [CSS Paged Media 3 §6](https://www.w3.org/TR/css-page-3/#margin-at-rules)) is parsed by `CreateMarginStyle`, whose inner `FillDeclarations` consumes the box's body through its closing `}`. But `CreateMarginStyle` takes the outer token by `ref` and leaves it pointing at the box's own `{` (where `CreateMarginSelector` left it). `FillDeclarations` then did:

```csharp
var marginStyle = CreateMarginStyle(ref marginToken);
parentPageRule.AppendChild(marginStyle);
token = marginToken;   // <-- stale: the box's '{', already consumed
```

so the loop re-entered on a stale token and skipped past everything up to the `@page` block's own `}` — dropping any trailing declarations and any further margin boxes.

A margin box that appears **last** in the block (the shape the existing `StyleSheetPageAtRulesAndProperties` test uses) is unaffected, since there's nothing after it — which is why this went unnoticed.

### Fix

Advance with `NextToken()` to the next real token after the consumed margin box. Declarations *before* a margin box already worked and are unchanged.

### Tests

3 tests in `Cases.cs`: a declaration after one margin box, declarations both before and after, and two margin boxes followed by a declaration — asserting both the margin rules and the trailing longhands. All 3 fail on `master`. The existing `@page` test (margin box last) stays green, along with the other 1262 tests, and all seven target frameworks build with no new warnings.
