### PR TITLE
Add :is(), retain argument selectors for :not()/:has()/:matches(), fix forgiving-list specificity

### DIFF
--- a/src/ExCSS.Tests/SelectorObjectModelTests.cs
+++ b/src/ExCSS.Tests/SelectorObjectModelTests.cs
@@ -1,0 +1,92 @@
+using System.Linq;
+using Xunit;
+
+namespace ExCSS.Tests
+{
+    public class SelectorObjectModelTests : CssConstructionFunctions
+    {
+        private static ISelector ParseSelector(string selector)
+        {
+            var sheet = ParseStyleSheet(selector + " { color: red }");
+            return ((StyleRule)sheet.Rules[0]).Selector;
+        }
+
+        private static ISelector Subject(string selector)
+        {
+            var sel = ParseSelector(selector);
+            return sel is CompoundSelector compound ? compound.Last() : sel;
+        }
+
+        [Fact]
+        public void NotProducesNotSelectorRetainingInnerSelector()
+        {
+            var not = Assert.IsType<NotSelector>(Subject("a:not(.foo)"));
+
+            Assert.IsType<ClassSelector>(not.Inner);
+            Assert.Equal(".foo", not.Inner.Text);
+            Assert.Equal("a:not(.foo)", ParseSelector("a:not(.foo)").Text);
+        }
+
+        [Fact]
+        public void HasProducesHasSelectorRetainingInnerSelector()
+        {
+            var has = Assert.IsType<HasSelector>(Subject("a:has(.foo)"));
+
+            Assert.Equal(".foo", has.Inner.Text);
+            Assert.Equal("a:has(.foo)", ParseSelector("a:has(.foo)").Text);
+        }
+
+        [Fact]
+        public void MatchesProducesMatchesSelectorRetainingInnerSelector()
+        {
+            var matches = Assert.IsType<MatchesSelector>(Subject("a:matches(.foo, #bar)"));
+
+            Assert.IsType<ListSelector>(matches.Inner);
+            Assert.Equal("matches", matches.Keyword);
+            Assert.Equal("a:matches(.foo,#bar)", ParseSelector("a:matches(.foo, #bar)").Text);
+        }
+
+        [Fact]
+        public void IsIsAnAliasOfMatchesAndRoundTripsAsIs()
+        {
+            var matches = Assert.IsType<MatchesSelector>(Subject("a:is(.foo, #bar)"));
+
+            Assert.Equal("is", matches.Keyword);
+            Assert.Equal("a:is(.foo,#bar)", ParseSelector("a:is(.foo, #bar)").Text);
+        }
+
+        [Theory]
+        // CSS Selectors 4 16.1: the specificity of :is()/:not()/:has() is that of the most specific complex
+        // selector in the argument. Priority is (inline, id, class, type).
+        [InlineData(":is(em, #foo)", 0, 1, 0, 0)]          // spec's own example -> like #foo
+        [InlineData(":not(em, strong#foo)", 0, 1, 0, 1)]   // spec's own example -> #foo + type
+        [InlineData("a:not(.foo)", 0, 0, 1, 1)]
+        [InlineData("a:has(.foo)", 0, 0, 1, 1)]
+        [InlineData("a:is(.foo, #bar)", 0, 1, 0, 1)]
+        public void ForgivingPseudoClassSpecificityIsMostSpecificArgument(string selector,
+            int inline, int id, int cls, int type)
+        {
+            var specificity = ParseSelector(selector).Specificity;
+
+            Assert.Equal(new Priority((byte)inline, (byte)id, (byte)cls, (byte)type), specificity);
+        }
+
+        [Fact]
+        public void ListSelectorSpecificityIsMaxNotSum()
+        {
+            // A comma-separated list's specificity is the static max of its alternatives, not their sum.
+            var list = Assert.IsType<ListSelector>(ParseSelector(".a, #b, c"));
+
+            Assert.Equal(new Priority(0, 1, 0, 0), list.Specificity);
+        }
+
+        [Fact]
+        public void CompoundSelectorSpecificityRemainsTheSum()
+        {
+            // A compound selector's members all constrain one element, so its specificity is still the sum.
+            var compound = Assert.IsType<CompoundSelector>(ParseSelector("a.foo.bar"));
+
+            Assert.Equal(new Priority(0, 0, 2, 1), compound.Specificity);
+        }
+    }
+}

--- a/src/ExCSS/Enumerations/PseudoClassNames.cs
+++ b/src/ExCSS/Enumerations/PseudoClassNames.cs
@@ -39,6 +39,7 @@
         public static readonly string Dir = "dir";
         public static readonly string Has = "has";
         public static readonly string Matches = "matches";
+        public static readonly string Is = "is";
         public static readonly string NthChild = "nth-child";
         public static readonly string NthLastChild = "nth-last-child";
         public static readonly string NthOfType = "nth-of-type";

--- a/src/ExCSS/Parser/SelectorConstructor.cs
+++ b/src/ExCSS/Parser/SelectorConstructor.cs
@@ -54,7 +54,8 @@ namespace ExCSS
                 {PseudoClassNames.Lang, _ => new LangFunctionState()},
                 {PseudoClassNames.Contains, _ => new ContainsFunctionState()},
                 {PseudoClassNames.Has, ctx => new HasFunctionState(ctx)},
-                {PseudoClassNames.Matches, ctx => new MatchesFunctionState(ctx)},
+                {PseudoClassNames.Matches, ctx => new MatchesFunctionState(ctx, PseudoClassNames.Matches)},
+                {PseudoClassNames.Is, ctx => new MatchesFunctionState(ctx, PseudoClassNames.Is)},
                 {PseudoClassNames.HostContext, ctx => new HostContextFunctionState(ctx)}
             };
 
@@ -523,13 +524,7 @@ namespace ExCSS
             {
                 var valid = _selector.IsValid;
                 var sel = _selector.GetResult();
-                if (valid)
-                {
-                    var code = PseudoClassNames.Not.StylesheetFunction(sel.Text);
-                    return PseudoClassSelector.Create( /*el => !sel.Match(el),*/ code);
-                }
-
-                return null;
+                return valid ? new NotSelector(sel) : null;
             }
 
             public override void Dispose()
@@ -563,14 +558,7 @@ namespace ExCSS
             {
                 var valid = _nested.IsValid;
                 var sel = _nested.GetResult();
-
-                if (!valid)
-                {
-                    return null;
-                }
-
-                var code = PseudoClassNames.Has.StylesheetFunction(sel.Text);
-                return PseudoClassSelector.Create( /*el => el.ChildNodes.QuerySelector(sel) != null,*/ code);
+                return valid ? new HasSelector(sel) : null;
             }
 
             public override void Dispose()
@@ -583,10 +571,12 @@ namespace ExCSS
         private sealed class MatchesFunctionState : FunctionState
         {
             private readonly SelectorConstructor _selector;
+            private readonly string _keyword;
 
-            public MatchesFunctionState(SelectorConstructor parent)
+            public MatchesFunctionState(SelectorConstructor parent, string keyword)
             {
                 _selector = parent.CreateChild();
+                _keyword = keyword;
             }
 
             protected override bool OnToken(Token token)
@@ -605,14 +595,7 @@ namespace ExCSS
             {
                 var valid = _selector.IsValid;
                 var sel = _selector.GetResult();
-                if (!valid)
-                {
-                    return null;
-                }
-
-                var code = PseudoClassNames.Matches.StylesheetFunction(sel.Text);
-                return PseudoClassSelector.Create( /*el => sel.Match(el),*/ code);
-
+                return valid ? new MatchesSelector(sel, _keyword) : null;
             }
 
             public override void Dispose()

--- a/src/ExCSS/Selectors/HasSelector.cs
+++ b/src/ExCSS/Selectors/HasSelector.cs
@@ -1,0 +1,31 @@
+﻿using System.IO;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// The relational pseudo-class <c>:has(S)</c> - matches an element with a descendant matching S.
+    /// Retains the parsed argument selector rather than collapsing it to a formatted string.
+    /// </summary>
+    public sealed class HasSelector : StylesheetNode, ISelector
+    {
+        public HasSelector(ISelector inner)
+        {
+            Inner = inner;
+        }
+
+        public ISelector Inner { get; }
+
+        // The specificity of :has() is the specificity of its most specific argument (CSS Selectors 4
+        // 16.1), which ListSelector.Specificity supplies as the static max when the argument is a list.
+        public Priority Specificity => Inner.Specificity;
+
+        public string Text => this.ToCss();
+
+        public override void ToCss(TextWriter writer, IStyleFormatter formatter)
+        {
+            writer.Write(":has(");
+            writer.Write(Inner.Text);
+            writer.Write(')');
+        }
+    }
+}

--- a/src/ExCSS/Selectors/ListSelector.cs
+++ b/src/ExCSS/Selectors/ListSelector.cs
@@ -1,10 +1,20 @@
 ﻿using System.IO;
+using System.Linq;
 
 namespace ExCSS
 {
     public sealed class ListSelector : Selectors, ISelector
     {
         public bool IsInvalid { get; internal set; }
+
+        // A comma-separated selector list's specificity is not the sum of its alternatives (that sum is
+        // only meaningful for a CompoundSelector, whose members all constrain one element at once). As the
+        // argument of :is()/:not()/:has() it is the static max across the alternatives - the most specific
+        // one, regardless of which (if any) matches a given element (CSS Selectors 4 16.1). A top-level
+        // list (".a, .b { }") is shorthand for separate rules, each with its own per-alternative
+        // specificity, so no single value is meaningful there; max is the closest sensible answer.
+        public override Priority Specificity =>
+            _selectors.Count == 0 ? Priority.Zero : _selectors.Max(s => s.Specificity);
 
         public override void ToCss(TextWriter writer, IStyleFormatter formatter)
         {

--- a/src/ExCSS/Selectors/MatchesSelector.cs
+++ b/src/ExCSS/Selectors/MatchesSelector.cs
@@ -1,0 +1,37 @@
+﻿using System.IO;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// The matches-any pseudo-class <c>:is(S)</c> / <c>:matches(S)</c> - matches an element that matches
+    /// any selector in S. <c>:is()</c> is the current name and <c>:matches()</c> the legacy alias; both
+    /// share this class, and <see cref="Keyword"/> controls which form it round-trips to.
+    /// </summary>
+    public sealed class MatchesSelector : StylesheetNode, ISelector
+    {
+        public MatchesSelector(ISelector inner, string keyword)
+        {
+            Inner = inner;
+            Keyword = keyword;
+        }
+
+        public ISelector Inner { get; }
+
+        public string Keyword { get; }
+
+        // The specificity of :is()/:matches() is the specificity of its most specific argument (CSS
+        // Selectors 4 16.1), which ListSelector.Specificity supplies as the static max for a list argument.
+        public Priority Specificity => Inner.Specificity;
+
+        public string Text => this.ToCss();
+
+        public override void ToCss(TextWriter writer, IStyleFormatter formatter)
+        {
+            writer.Write(':');
+            writer.Write(Keyword);
+            writer.Write('(');
+            writer.Write(Inner.Text);
+            writer.Write(')');
+        }
+    }
+}

--- a/src/ExCSS/Selectors/NotSelector.cs
+++ b/src/ExCSS/Selectors/NotSelector.cs
@@ -1,0 +1,31 @@
+﻿using System.IO;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// The negation pseudo-class <c>:not(S)</c> - matches an element that does not match S. Retains the
+    /// parsed argument selector rather than collapsing it to a formatted string.
+    /// </summary>
+    public sealed class NotSelector : StylesheetNode, ISelector
+    {
+        public NotSelector(ISelector inner)
+        {
+            Inner = inner;
+        }
+
+        public ISelector Inner { get; }
+
+        // The specificity of :not() is the specificity of its most specific argument (CSS Selectors 4
+        // 16.1), which ListSelector.Specificity supplies as the static max when the argument is a list.
+        public Priority Specificity => Inner.Specificity;
+
+        public string Text => this.ToCss();
+
+        public override void ToCss(TextWriter writer, IStyleFormatter formatter)
+        {
+            writer.Write(":not(");
+            writer.Write(Inner.Text);
+            writer.Write(')');
+        }
+    }
+}

--- a/src/ExCSS/Selectors/Selectors.cs
+++ b/src/ExCSS/Selectors/Selectors.cs
@@ -13,7 +13,10 @@ namespace ExCSS
             _selectors = new List<ISelector>();
         }
 
-        public Priority Specificity
+        // A CompoundSelector's specificity is the sum of its members - they all constrain the same
+        // element. A ListSelector overrides this, because a comma-separated list's specificity is not a
+        // sum (see ListSelector).
+        public virtual Priority Specificity
         {
             get
             {


### PR DESCRIPTION
### Problem

`:not()`, `:has()` and `:matches()` throw away their parsed argument. Each function state formats the inner selector back to a string and wraps it in an opaque `PseudoClassSelector`:

```csharp
var code = PseudoClassNames.Not.StylesheetFunction(sel.Text);
return PseudoClassSelector.Create(code);   // inner ISelector discarded
```

So after parsing `a:not(.foo)` there is no way to reach the `.foo` selector object — only its round-tripped text survives. And `:is()`, the current name for `:matches()` ([CSS Selectors 4 §4.2](https://www.w3.org/TR/selectors-4/#matches)), isn't recognized at all.

### Changes

- **`NotSelector` / `HasSelector` / `MatchesSelector`** — each retains the parsed argument `ISelector` (exposed as `Inner`) and round-trips correctly.
- **`:is()`** as the modern alias of `:matches()`. Both share `MatchesSelector`; a `Keyword` field controls whether it serializes as `:is(...)` or `:matches(...)`.
- **Forgiving-list specificity** per [CSS Selectors 4 §16.1](https://www.w3.org/TR/selectors-4/#specificity-rules):

  > The specificity of an :is(), :not(), or :has() pseudo-class is replaced by the specificity of the most specific complex selector in its selector list argument.

  A selector *list* must therefore report the **max** of its alternatives, not their sum. `Selectors.Specificity` becomes `virtual` and `ListSelector` overrides it to the max. `CompoundSelector` keeps the sum — correct, since its members all constrain one element.

### Verified against the spec's own examples

| selector | spec | this PR |
| --- | --- | --- |
| `:is(em, #foo)` | `(1,0,0)` | ✓ |
| `:not(em, strong#foo)` | `(1,0,1)` | ✓ |

### Tests

11 tests in `SelectorObjectModelTests.cs`: each function produces its typed selector and retains `Inner`; `:is()`/`:matches()` round-trip to their own keyword; the two spec examples plus `a:not(.foo)`/`a:has(.foo)`/`a:is(.foo, #bar)` specificities; and that a list's specificity is the max while a compound's stays the sum.

The full suite (1263 existing tests) stays green — the specificity change regresses nothing — and all seven target frameworks build with no new warnings. The new selector types are additive; the only behavioural change to an existing type is `ListSelector.Specificity` (sum → max), which is the spec fix above.
