### PR TITLE
Register the ::marker pseudo-element

### DIFF
--- a/src/ExCSS.Tests/SelectorsTests.cs
+++ b/src/ExCSS.Tests/SelectorsTests.cs
@@ -146,6 +146,31 @@ public class SelectorsTests
         Assert.Equal(0, sheet.Rules.Length);
     }
 
+    [Theory]
+    // ::marker is a standard pseudo-element (CSS Lists 3 6.1). It was unregistered, so a rule using it
+    // was rejected wholesale rather than parsed. Only the two-colon form exists - unlike ::before/::after,
+    // ::marker has no one-colon legacy spelling.
+    [InlineData("li::marker", "li::marker")]
+    [InlineData("::marker", "::marker")]
+    public void MarkerPseudoElementIsParsed(string selector, string expectedText)
+    {
+        var sheet = new StylesheetParser().Parse(selector + " { color: red }");
+
+        Assert.Equal(1, sheet.Rules.Length);
+        Assert.Equal(expectedText, ((StyleRule)sheet.Rules[0]).SelectorText);
+    }
+
+    [Fact]
+    public void MarkerPseudoElementProducesPseudoElementSelector()
+    {
+        var sheet = new StylesheetParser().Parse("li::marker { color: red }");
+        var selector = ((StyleRule)sheet.Rules[0]).Selector;
+        var subject = selector is CompoundSelector compound ? compound.Last() : selector;
+
+        var pseudo = Assert.IsType<PseudoElementSelector>(subject);
+        Assert.Equal("marker", pseudo.Name);
+    }
+
     private static bool HasStandardPseudoElementSelector(ISelector selector, bool negate = false)
     {
         if (selector is PseudoElementSelector pes)

--- a/src/ExCSS/Enumerations/PseudoElementNames.cs
+++ b/src/ExCSS/Enumerations/PseudoElementNames.cs
@@ -4,6 +4,7 @@
     {
         public static readonly string Before = "before";
         public static readonly string After = "after";
+        public static readonly string Marker = "marker";
         public static readonly string Selection = "selection";
         public static readonly string FirstLine = "first-line";
         public static readonly string FirstLetter = "first-letter";

--- a/src/ExCSS/Factories/PseudoElementSelectorFactory.cs
+++ b/src/ExCSS/Factories/PseudoElementSelectorFactory.cs
@@ -20,6 +20,7 @@ namespace ExCSS
                     // some implementations are dubious (first-line, first-letter, ...)
                     PseudoElementNames.Before,
                     PseudoElementNames.After,
+                    PseudoElementNames.Marker,
                     PseudoElementNames.Selection,
                     PseudoElementNames.FirstLine,
                     PseudoElementNames.FirstLetter,


### PR DESCRIPTION
### Problem

`li::marker { color: red }` fails to parse — `sheet.Rules.Length` is 0, the whole rule is dropped.

`::marker` is a standard pseudo-element ([CSS Lists 3 §6.1](https://www.w3.org/TR/css-lists-3/#marker-pseudo)), but it is missing from the registered set in `PseudoElementSelectorFactory`:

```csharp
new HashSet<string>(StringComparer.OrdinalIgnoreCase)
{
    PseudoElementNames.Before,
    PseudoElementNames.After,
    // PseudoElementNames.Marker  <-- absent
    PseudoElementNames.Selection,
    PseudoElementNames.FirstLine,
    PseudoElementNames.FirstLetter,
    PseudoElementNames.Content,
}
```

So `Create("marker")` returns null (unless `AllowInvalidSelectors` is set), and the selector — and its rule — is discarded.

### Fix

Add `PseudoElementNames.Marker = "marker"` and register it in the factory, exactly like the other pseudo-elements. It now parses to a `PseudoElementSelector` with `Name == "marker"` and round-trips as `::marker`.

Only the two-colon form is registered. Unlike `::before`/`::after`, `::marker` has no one-colon legacy spelling (it postdates CSS2), so `:marker` stays invalid.

### Scope note

This is the parse fix only. In the fork this came from, `::marker` registration rode along with a larger rework that also gives `:first-child`/`:only-child`/etc. dedicated selector subtypes — but those already parse correctly here (identical text and specificity), so that part is an object-model change specific to that fork's matching engine, not a parsing or spec-conformance fix, and is left out.

### Tests

3 tests in `SelectorsTests.cs`: `li::marker` and bare `::marker` parse and round-trip, and the subject is a `PseudoElementSelector` named `marker`. All 3 fail on `master`. The full suite (1263 existing tests) stays green, and all seven target frameworks build with no new warnings.
