### PR TITLE
Accept revert/revert-layer/unset on every property

### DIFF
--- a/src/ExCSS.Tests/PropertyTests/GlobalKeywordPropertyTests.cs
+++ b/src/ExCSS.Tests/PropertyTests/GlobalKeywordPropertyTests.cs
@@ -1,0 +1,44 @@
+using Xunit;
+
+namespace ExCSS.Tests.PropertyTests
+{
+    public class GlobalKeywordPropertyTests : CssConstructionFunctions
+    {
+        [Theory]
+        // The five CSS-wide keywords are valid on every property (CSS Cascade 4 7.3; revert-layer is
+        // Cascade 5). Before this, only inherit/initial were accepted on properties using OrDefault.
+        [InlineData("color", "inherit")]
+        [InlineData("color", "initial")]
+        [InlineData("color", "unset")]
+        [InlineData("color", "revert")]
+        [InlineData("color", "revert-layer")]
+        [InlineData("display", "unset")]
+        [InlineData("display", "revert")]
+        [InlineData("text-align", "unset")]
+        [InlineData("float", "revert")]
+        [InlineData("white-space", "revert-layer")]
+        [InlineData("font-weight", "unset")]
+        [InlineData("line-height", "revert")]
+        public void CssWideKeywordIsAcceptedOnEveryProperty(string property, string keyword)
+        {
+            var declaration = ParseDeclaration($"{property}: {keyword}");
+
+            Assert.Equal(property, declaration.Name);
+            Assert.True(declaration.HasValue);
+            Assert.Equal(keyword, declaration.Value);
+        }
+
+        [Theory]
+        // A misspelled global keyword is still rejected - the change widened the accepted set, not the
+        // grammar around it.
+        [InlineData("color", "reverts")]
+        [InlineData("color", "un-set")]
+        [InlineData("display", "revertlayer")]
+        public void MisspelledGlobalKeywordIsRejected(string property, string keyword)
+        {
+            var declaration = ParseDeclaration($"{property}: {keyword}");
+
+            Assert.False(declaration.HasValue);
+        }
+    }
+}

--- a/src/ExCSS/Extensions/ValueConverterExtensions.cs
+++ b/src/ExCSS/Extensions/ValueConverterExtensions.cs
@@ -132,12 +132,17 @@ namespace ExCSS
 
         public static IValueConverter OrDefault(this IValueConverter primary)
         {
-            return primary.OrInherit().Or(Keywords.Initial);
+            // inherit/initial/revert/revert-layer/unset are CSS-wide keywords, valid on every property
+            // (CSS Cascade 4 7.3, Cascade 5 for revert-layer). OrGlobalValue is the full set.
+            return primary.OrGlobalValue();
         }
 
         public static IValueConverter OrDefault<T>(this IValueConverter primary, T value)
         {
-            return primary.OrInherit().Or(Keywords.Initial, value);
+            return primary.OrInherit().Or(Keywords.Initial, value)
+                          .Or(Keywords.Revert)
+                          .Or(Keywords.RevertLayer)
+                          .Or(Keywords.Unset);
         }
 
         public static IValueConverter OrInherit(this IValueConverter primary)


### PR DESCRIPTION
### Problem

`revert`, `revert-layer` and `unset` are rejected on most properties, while `inherit` and `initial` work:

```css
color: unset;              /* rejected */
display: revert;           /* rejected */
white-space: revert-layer; /* rejected */
color: inherit;            /* fine */
```

All five are **CSS-wide keywords**, valid on *every* property ([CSS Cascade 4 §7.3](https://www.w3.org/TR/css-cascade-4/#defaulting-keywords); `revert-layer` is [Cascade 5](https://www.w3.org/TR/css-cascade-5/#defaulting-keywords)).

`OrGlobalValue` already accepts all five, but the widely-used `OrDefault` accepts only `inherit` and `initial`:

```csharp
public static IValueConverter OrDefault(this IValueConverter primary)
{
    return primary.OrInherit().Or(Keywords.Initial);   // no revert / revert-layer / unset
}
```

so any property converter built with `OrDefault` (the majority) rejects the other three.

### Fix

Route `OrDefault` through `OrGlobalValue`, and extend the defaulted overload (`OrDefault<T>`) with the same three keywords. The `Keywords.Revert`/`RevertLayer`/`Unset` constants already exist.

### Tests

15 cases in `PropertyTests/GlobalKeywordPropertyTests.cs`: all five keywords across `color`, `display`, `text-align`, `float`, `white-space`, `font-weight`, `line-height`; plus misspellings (`reverts`, `un-set`, `revertlayer`) that must stay rejected, confirming the accepted *set* widened without loosening the grammar.

12 fail on `master`. The full suite (1263 existing tests) stays green, and all seven target frameworks build with no new warnings.
