### PR TITLE
Add the hyphens property

### DIFF
--- a/src/ExCSS.Tests/PropertyTests/TextProperty.cs
+++ b/src/ExCSS.Tests/PropertyTests/TextProperty.cs
@@ -789,5 +789,35 @@
 			var concrete = (OverflowWrapProperty)property;
 			Assert.False(property.HasValue);
 		}
+
+        [Theory]
+        // hyphens: none | manual | auto (CSS Text 3 6.1). It is an inherited property; the initial value
+        // is manual.
+        [InlineData("none")]
+        [InlineData("manual")]
+        [InlineData("auto")]
+        [InlineData("AUTO")]
+        public void HyphensLegalValues(string value)
+        {
+            var property = ParseDeclaration($"hyphens: {value}");
+
+            Assert.Equal("hyphens", property.Name);
+            Assert.IsType<HyphensProperty>(property);
+            var concrete = (HyphensProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Equal(value.ToLowerInvariant(), concrete.Value);
+        }
+
+        [Theory]
+        [InlineData("hyphens: always")]
+        [InlineData("hyphens: 3")]
+        [InlineData("hyphens: none manual")]
+        public void HyphensIllegalValues(string snippet)
+        {
+            var property = ParseDeclaration(snippet);
+
+            Assert.IsType<HyphensProperty>(property);
+            Assert.False(property.HasValue);
+        }
 	}
 }

--- a/src/ExCSS/Enumerations/Hyphens.cs
+++ b/src/ExCSS/Enumerations/Hyphens.cs
@@ -1,0 +1,9 @@
+﻿namespace ExCSS
+{
+    public enum Hyphens : byte
+    {
+        None,
+        Manual,
+        Auto
+    }
+}

--- a/src/ExCSS/Enumerations/Keywords.cs
+++ b/src/ExCSS/Enumerations/Keywords.cs
@@ -5,6 +5,7 @@
         public static readonly string Important = "important";
         public static readonly string Inherit = "inherit";
         public static readonly string Initial = "initial";
+        public static readonly string Manual = "manual";
         public static readonly string None = "none";
         public static readonly string Auto = "auto";
         public static readonly string From = "from";

--- a/src/ExCSS/Enumerations/PropertyNames.cs
+++ b/src/ExCSS/Enumerations/PropertyNames.cs
@@ -127,6 +127,7 @@
         public static readonly string GlyphOrientationHorizontal = "glyph-orientation-horizontal";
         public static readonly string GlyphOrientationVertical = "glyph-orientation-vertical";
         public static readonly string Height = "height";
+        public static readonly string Hyphens = "hyphens";
         public static readonly string ImeMode = "ime-mode";
         public static readonly string JustifyContent = "justify-content";
         public static readonly string LayoutGrid = "layout-grid";

--- a/src/ExCSS/Factories/PropertyFactory.cs
+++ b/src/ExCSS/Factories/PropertyFactory.cs
@@ -220,7 +220,8 @@ namespace ExCSS
                 PropertyNames.ColumnGap);
 
             AddLonghand(PropertyNames.Height, () => new HeightProperty(), true);
-            
+            AddLonghand(PropertyNames.Hyphens, () => new HyphensProperty());
+
             AddLonghand(PropertyNames.JustifyContent, () => new JustifyContentProperty());
             
             AddLonghand(PropertyNames.Left, () => new LeftProperty(), true);

--- a/src/ExCSS/Model/Converters.cs
+++ b/src/ExCSS/Model/Converters.cs
@@ -258,6 +258,7 @@ namespace ExCSS
         public static readonly IValueConverter HorizontalAlignmentConverter = Map.HorizontalAlignments.ToConverter();
         public static readonly IValueConverter VerticalAlignmentConverter = Map.VerticalAlignments.ToConverter();
         public static readonly IValueConverter WhitespaceConverter = Map.WhitespaceModes.ToConverter();
+        public static readonly IValueConverter HyphensConverter = Map.HyphensModes.ToConverter();
         public static readonly IValueConverter TextTransformConverter = Map.TextTransforms.ToConverter();
         public static readonly IValueConverter TextAlignLastConverter = Map.TextAlignmentsLast.ToConverter();
         public static readonly IValueConverter TextAnchorConverter = Map.TextAnchors.ToConverter();

--- a/src/ExCSS/Model/Map.cs
+++ b/src/ExCSS/Model/Map.cs
@@ -14,6 +14,13 @@ namespace ExCSS
                 {Keywords.PreWrap, Whitespace.PreWrap},
                 {Keywords.PreLine, Whitespace.PreLine}
             };
+        public static readonly Dictionary<string, Hyphens> HyphensModes =
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                {Keywords.None, Hyphens.None},
+                {Keywords.Manual, Hyphens.Manual},
+                {Keywords.Auto, Hyphens.Auto}
+            };
         public static readonly Dictionary<string, TextTransform> TextTransforms =
             new(StringComparer.OrdinalIgnoreCase)
             {

--- a/src/ExCSS/StyleProperties/Text/HyphensProperty.cs
+++ b/src/ExCSS/StyleProperties/Text/HyphensProperty.cs
@@ -1,0 +1,15 @@
+﻿namespace ExCSS
+{
+    internal sealed class HyphensProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter =
+            Converters.HyphensConverter.OrDefault(Hyphens.Manual);
+
+        internal HyphensProperty()
+            : base(PropertyNames.Hyphens, PropertyFlags.Inherited)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}


### PR DESCRIPTION
### Feature

Adds the `hyphens` property ([CSS Text 3 §6.1](https://www.w3.org/TR/css-text-3/#hyphens-property)):

```
hyphens: none | manual | auto
```

It is inherited, with an initial value of `manual`.

### Implementation

Follows the existing keyword-property pattern (e.g. `white-space`): a `Hyphens` enum, a `Map.HyphensModes` dictionary, a `Converters.HyphensConverter`, the new `manual` keyword, and an inherited `HyphensProperty` registered in `PropertyFactory`.

### Tests

7 cases in `PropertyTests/TextProperty.cs`: the three keywords (plus a case-insensitivity check) parse and round-trip; `always`, a number, and two keywords together are rejected.

The four legal-value tests fail on `master` (the property is unknown there). The full suite (1263 existing tests) stays green, and all seven target frameworks build with no new warnings.
