### PR TITLE
Add the aspect-ratio property

### DIFF
--- a/src/ExCSS.Tests/PropertyTests/AspectRatioProperty.cs
+++ b/src/ExCSS.Tests/PropertyTests/AspectRatioProperty.cs
@@ -1,0 +1,56 @@
+using Xunit;
+
+namespace ExCSS.Tests.PropertyTests
+{
+    public class AspectRatioPropertyTests : CssConstructionFunctions
+    {
+        [Theory]
+        // aspect-ratio: [ auto || <ratio> ] (CSS Sizing 4 4.1). The serialized form drops whitespace
+        // around the slash, matching how every other value round-trips through TokenValue.
+        [InlineData("auto", "auto")]
+        [InlineData("16 / 9", "16/9")]
+        [InlineData("16/9", "16/9")]
+        [InlineData("1.5", "1.5")]
+        [InlineData("2", "2")]
+        [InlineData("auto 16 / 9", "auto 16/9")]
+        [InlineData("16 / 9 auto", "16/9 auto")]
+        [InlineData("0.5 / 0.25", "0.5/0.25")]
+        public void AspectRatioLegalValues(string value, string expected)
+        {
+            var property = ParseDeclaration($"aspect-ratio: {value}");
+
+            Assert.Equal("aspect-ratio", property.Name);
+            Assert.IsType<AspectRatioProperty>(property);
+            var concrete = (AspectRatioProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Equal(expected, concrete.Value);
+        }
+
+        [Theory]
+        [InlineData("aspect-ratio: none")]
+        [InlineData("aspect-ratio: 16 /")]
+        [InlineData("aspect-ratio: / 9")]
+        [InlineData("aspect-ratio: 16 / 9 / 3")]
+        [InlineData("aspect-ratio: -16 / 9")]
+        [InlineData("aspect-ratio: auto auto")]
+        [InlineData("aspect-ratio: 16 9")]
+        [InlineData("aspect-ratio: 16px / 9")]
+        public void AspectRatioIllegalValues(string snippet)
+        {
+            var property = ParseDeclaration(snippet);
+
+            Assert.IsType<AspectRatioProperty>(property);
+            Assert.False(property.HasValue);
+        }
+
+        [Theory]
+        [InlineData("aspect-ratio: inherit")]
+        [InlineData("aspect-ratio: initial")]
+        public void AspectRatioGlobalKeywords(string snippet)
+        {
+            var property = ParseDeclaration(snippet);
+
+            Assert.True(property.HasValue);
+        }
+    }
+}

--- a/src/ExCSS/Enumerations/PropertyNames.cs
+++ b/src/ExCSS/Enumerations/PropertyNames.cs
@@ -40,6 +40,7 @@
         public static readonly string BorderBottomRightRadius = "border-bottom-right-radius";
         public static readonly string BoxShadow = "box-shadow";
         public static readonly string BoxSizing = "box-sizing";
+        public static readonly string AspectRatio = "aspect-ratio";
         public static readonly string BoxDecorationBreak = "box-decoration-break";
         public static readonly string BreakAfter = "break-after";
         public static readonly string BreakBefore = "break-before";

--- a/src/ExCSS/Factories/PropertyFactory.cs
+++ b/src/ExCSS/Factories/PropertyFactory.cs
@@ -62,6 +62,7 @@ namespace ExCSS
             AddLonghand(PropertyNames.BorderSpacing, () => new BorderSpacingProperty());
             AddLonghand(PropertyNames.BorderCollapse, () => new BorderCollapseProperty());
             AddLonghand(PropertyNames.BoxSizing, () => new BoxSizingProperty());
+            AddLonghand(PropertyNames.AspectRatio, () => new AspectRatioProperty());
             AddLonghand(PropertyNames.BoxShadow, () => new BoxShadowProperty(), true);
             AddLonghand(PropertyNames.BoxDecorationBreak, () => new BoxDecorationBreak());
             AddLonghand(PropertyNames.BreakAfter, () => new BreakAfterProperty());

--- a/src/ExCSS/StyleProperties/Box/AspectRatioProperty.cs
+++ b/src/ExCSS/StyleProperties/Box/AspectRatioProperty.cs
@@ -1,0 +1,14 @@
+﻿namespace ExCSS
+{
+    internal sealed class AspectRatioProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = new AspectRatioValueConverter().OrDefault();
+
+        internal AspectRatioProperty()
+            : base(PropertyNames.AspectRatio)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/ValueConverters/AspectRatioValueConverter.cs
+++ b/src/ExCSS/ValueConverters/AspectRatioValueConverter.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// Validates the <c>aspect-ratio</c> value <c>[ auto || &lt;ratio&gt; ]</c> (CSS Sizing 4 4.1), where
+    /// <c>&lt;ratio&gt; = &lt;number [0,∞]&gt; [ / &lt;number [0,∞]&gt; ]?</c>. The <c>||</c> permits
+    /// <c>auto</c> and the ratio in either order, and either alone. The authored text is preserved.
+    /// </summary>
+    internal sealed class AspectRatioValueConverter : IValueConverter
+    {
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            var tokens = value.Where(t => t.Type != TokenType.Whitespace).ToArray();
+
+            if (tokens.Length == 0) return null;
+
+            var index = 0;
+            var hasAuto = false;
+
+            if (IsAuto(tokens[index]))
+            {
+                hasAuto = true;
+                index++;
+            }
+
+            if (index == tokens.Length) return hasAuto ? new AspectRatioValue(value) : null;
+
+            if (!TryConsumeRatio(tokens, ref index)) return null;
+
+            // "||" allows a trailing auto too (e.g. "16 / 9 auto"), but only if one wasn't already given.
+            if (index < tokens.Length && !hasAuto && IsAuto(tokens[index])) index++;
+
+            return index == tokens.Length ? new AspectRatioValue(value) : null;
+        }
+
+        public IPropertyValue Construct(Property[] properties)
+        {
+            return properties.Guard<AspectRatioValue>();
+        }
+
+        private static bool TryConsumeRatio(IReadOnlyList<Token> tokens, ref int index)
+        {
+            if (index >= tokens.Count || !IsNonNegativeNumber(tokens[index])) return false;
+            index++;
+
+            if (index < tokens.Count && IsSlash(tokens[index]))
+            {
+                index++;
+                if (index >= tokens.Count || !IsNonNegativeNumber(tokens[index])) return false;
+                index++;
+            }
+
+            return true;
+        }
+
+        private static bool IsAuto(Token token) =>
+            token.Type == TokenType.Ident && token.Data.Isi(Keywords.Auto);
+
+        private static bool IsSlash(Token token) =>
+            token.Type == TokenType.Delim && token.Data == "/";
+
+        private static bool IsNonNegativeNumber(Token token) =>
+            token is NumberToken number && number.Value >= 0f;
+
+        private sealed class AspectRatioValue : IPropertyValue
+        {
+            public AspectRatioValue(IEnumerable<Token> tokens)
+            {
+                Original = new TokenValue(tokens);
+            }
+
+            public string CssText => Original.Text;
+
+            public TokenValue Original { get; }
+
+            public TokenValue ExtractFor(string name) => Original;
+        }
+    }
+}


### PR DESCRIPTION
### Feature

Adds the `aspect-ratio` property ([CSS Sizing 4 §4.1](https://www.w3.org/TR/css-sizing-4/#aspect-ratio)):

```
aspect-ratio: [ auto || <ratio> ]
<ratio> = <number [0,∞]> [ / <number [0,∞]> ]?
```

`auto` and the ratio may appear in either order, or either alone (the `||` combinator).

### Implementation

A dedicated `AspectRatioValueConverter` validates the grammar and preserves the authored text. A denominator defaults to `1` when omitted, negative numbers are rejected, and `auto` may appear before or after the ratio but not twice.

Registered as `AspectRatioProperty` in `PropertyFactory`.

### Tests

18 cases in `PropertyTests/AspectRatioProperty.cs`:

- legal: `auto`, `16 / 9`, `16/9`, a single `<number>`, `auto 16 / 9`, `16 / 9 auto`, decimals
- illegal: `none`, `16 /`, `/ 9`, three terms, negative, `auto auto`, two bare numbers, a length instead of a number
- `inherit`/`initial`

The legal and illegal cases fail on `master` (the property is unknown). The full suite (1263 existing tests) stays green, and all seven target frameworks build with no new warnings.
