### PR TITLE
Support font-style: oblique <angle>

### DIFF
--- a/src/ExCSS.Tests/FontProperty.cs
+++ b/src/ExCSS.Tests/FontProperty.cs
@@ -221,6 +221,44 @@
             Assert.Equal("oblique", concrete.Value);
         }
 
+        [Theory]
+        // font-style: oblique <angle> (CSS Fonts 4 2.4). "oblique" alone still works (above).
+        [InlineData("oblique 14deg", "oblique 14deg")]
+        [InlineData("oblique -10deg", "oblique -10deg")]
+        [InlineData("oblique 0deg", "oblique 0deg")]
+        [InlineData("oblique 40grad", "oblique 40grad")]
+        public void CssFontStyleObliqueAngleLegal(string value, string expected)
+        {
+            var property = ParseDeclaration($"font-style: {value}");
+            Assert.Equal("font-style", property.Name);
+            Assert.IsType<FontStyleProperty>(property);
+            var concrete = (FontStyleProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Equal(expected, concrete.Value);
+        }
+
+        [Theory]
+        [InlineData("font-style: oblique 14px")]   // angle required, not a length
+        [InlineData("font-style: italic 14deg")]   // only oblique takes an angle
+        [InlineData("font-style: 14deg")]
+        public void CssFontStyleObliqueAngleIllegal(string snippet)
+        {
+            var property = ParseDeclaration(snippet);
+            Assert.IsType<FontStyleProperty>(property);
+            Assert.False(property.HasValue);
+        }
+
+        [Fact]
+        public void CssFontShorthandWithoutStyleReserializes()
+        {
+            // Regression: reconstructing the omitted font-style longhand ran the oblique-angle converter
+            // on empty input. This must not throw and must not spuriously produce "oblique".
+            var sheet = ParseStyleSheet(".a { font: bold 12px serif }");
+            var style = ((StyleRule)sheet.Rules[0]).Style;
+
+            Assert.DoesNotContain("oblique", style.ToCss());
+        }
+
         [Fact]
         public void CssFontStyleNormalImportantLegal()
         {

--- a/src/ExCSS.Tests/Property.cs
+++ b/src/ExCSS.Tests/Property.cs
@@ -1304,5 +1304,40 @@
             Assert.Equal("my-Property", property.Name);
             Assert.IsType<UnknownProperty>(property);
         }
+
+        [Fact]
+        public void StartsWithConverterOnEmptyInputReturnsNull()
+        {
+            // ConvertDefault() feeds an empty token sequence, and VaryStart falls back to it once the token
+            // list is exhausted. Every other converter answers "no match"; this one dereferenced the
+            // exhausted enumerator's Current.
+            var converter = Converters.IntegerConverter.StartsWithDelimiter();
+
+            Assert.Null(converter.ConvertDefault());
+        }
+
+        [Fact]
+        public void StartsWithConverterOnWhitespaceOnlyInputReturnsNull()
+        {
+            var converter = Converters.IntegerConverter.StartsWithDelimiter();
+
+            Assert.Null(converter.Convert(new[] {Token.Whitespace, Token.Whitespace}));
+        }
+
+        [Theory]
+        // RatioConverter is the one composition that puts StartsWithDelimiter behind an ordered converter
+        // (WithOrder(IntegerConverter.Required(), IntegerConverter.StartsWithDelimiter().Required())), so
+        // these guard the nearest real-world path to the empty-input branch. They pass either way today -
+        // the ordered converter happens to reject the incomplete ratio before falling back to
+        // ConvertDefault - and exist to keep it that way.
+        [InlineData("@media (aspect-ratio: 16) { p { color: red } }")]
+        [InlineData("@media (device-aspect-ratio: 16) { p { color: red } }")]
+        [InlineData("@media (min-aspect-ratio: 16) { p { color: red } }")]
+        public void IncompleteRatioMediaFeatureDoesNotThrow(string source)
+        {
+            var sheet = ParseStyleSheet(source);
+
+            Assert.Equal(1, sheet.Rules.Length);
+        }
     }
 }

--- a/src/ExCSS/Model/Converters.cs
+++ b/src/ExCSS/Model/Converters.cs
@@ -270,7 +270,15 @@ namespace ExCSS
         public static readonly IValueConverter ContainerTypeConverter = Map.ContainerTypes.ToConverter();
         public static readonly IValueConverter ClearModeConverter = Map.ClearModes.ToConverter();
         public static readonly IValueConverter FontStretchConverter = Map.FontStretches.ToConverter();
-        public static readonly IValueConverter FontStyleConverter = Map.FontStyles.ToConverter();
+        // "oblique" alone matches via the plain keyword map (tried first); "oblique <angle>" (CSS Fonts 4
+        // 2.4, e.g. "oblique 14deg") only reaches the StartsWithValueConverter branch once the plain
+        // single-identifier match has failed - i.e. there are more tokens to account for. AngleConverter is
+        // deliberately not Option()-wrapped here: StartsWithValueConverter treats "the wrapped converter
+        // returned non-null" as its own "matched" signal, and an Option() converter never returns null, so
+        // every other font-style value would then falsely reconstruct as "oblique" when the font shorthand
+        // is re-serialized from its longhands.
+        public static readonly IValueConverter FontStyleConverter = Map.FontStyles.ToConverter()
+            .Or(new StartsWithValueConverter(TokenType.Ident, Keywords.Oblique, AngleConverter));
         public static readonly IValueConverter FontWeightConverter = Map.FontWeights.ToConverter();
         public static readonly IValueConverter SystemFontConverter = Map.SystemFonts.ToConverter();
         public static readonly IValueConverter StrokeLinecapConverter = Map.StrokeLinecaps.ToConverter();

--- a/src/ExCSS/ValueConverters/StartsWithValueConverter.cs
+++ b/src/ExCSS/ValueConverters/StartsWithValueConverter.cs
@@ -37,10 +37,16 @@ namespace ExCSS
         {
             using var enumerator = values.GetEnumerator();
 
-            while (enumerator.MoveNext() && enumerator.Current.Type == TokenType.Whitespace)
+            bool hasCurrent;
+
+            while ((hasCurrent = enumerator.MoveNext()) && enumerator.Current.Type == TokenType.Whitespace)
             {
                 //Empty on purpose.
             }
+
+            // Empty (or whitespace-only) input - which ConvertDefault supplies, and VaryStart falls back to -
+            // must resolve to "no match" rather than dereferencing an exhausted enumerator's Current.
+            if (!hasCurrent) return null;
 
             if (enumerator.Current.Type != _type || !enumerator.Current.Data.Isi(_data)) return null;
             var list = new List<Token>();


### PR DESCRIPTION
### Feature

`font-style` accepts an optional angle after `oblique` ([CSS Fonts 4 §2.4](https://www.w3.org/TR/css-fonts-4/#font-style-prop)):

```css
font-style: oblique 14deg;
font-style: oblique -10deg;
```

`FontStyleConverter` accepted only the plain keywords (`normal`/`italic`/`oblique`), so any `oblique <angle>` was rejected.

### Implementation

Compose the keyword map with a `StartsWithValueConverter` matching `oblique` followed by an `<angle>`.

The angle is **deliberately not `Option()`-wrapped**: `StartsWithValueConverter` treats a non-null wrapped result as "matched", and an `Option()` converter never returns null — so every *other* `font-style` value (plain keywords, absent) would then falsely reconstruct as `oblique` when the `font` shorthand is re-serialized from its longhands. A regression test pins this.

### Dependency

Reconstructing an omitted `font-style` longhand (e.g. from `font: bold 12px serif`) runs this converter on **empty** input, which throws a `NullReferenceException` on `master`. This branch includes the one-line fix for that, also submitted standalone as **"Return null from StartsWithValueConverter on empty input"** (#196). If that merges first, this rebases cleanly; if not, it's self-contained.

### Tests

- 4 legal `oblique <angle>` values (`deg`, negative, zero, `grad`)
- 3 illegal (`oblique 14px`, `italic 14deg`, bare `14deg`)
- a regression test that `font: bold 12px serif` re-serializes without throwing and without a spurious `oblique`

The full suite (1263 existing tests) stays green, and all seven target frameworks build with no new warnings.
