### PR TITLE
Add clip-path with basic shapes

### DIFF
--- a/src/ExCSS.Tests/PropertyTests/ClipPathProperty.cs
+++ b/src/ExCSS.Tests/PropertyTests/ClipPathProperty.cs
@@ -1,0 +1,62 @@
+using Xunit;
+
+namespace ExCSS.Tests.PropertyTests
+{
+    public class ClipPathPropertyTests : CssConstructionFunctions
+    {
+        [Theory]
+        // clip-path: none | <basic-shape> (CSS Masking 1 5.1 / CSS Shapes 1 3).
+        [InlineData("none")]
+        [InlineData("circle()")]
+        [InlineData("circle(50%)")]
+        [InlineData("circle(5em at center)")]
+        [InlineData("circle(closest-side at 30% 40%)")]
+        [InlineData("circle(farthest-side)")]
+        [InlineData("ellipse(50% 40%)")]
+        [InlineData("ellipse(closest-side farthest-side at center)")]
+        [InlineData("ellipse()")]
+        [InlineData("inset(10px)")]
+        [InlineData("inset(10px 20px)")]
+        [InlineData("inset(10px 20px 30px 40px)")]
+        [InlineData("inset(10px round 5px)")]
+        [InlineData("polygon(0 0, 100% 0, 100% 100%)")]
+        [InlineData("polygon(evenodd, 0 0, 100% 0, 50% 100%)")]
+        [InlineData("polygon(nonzero, 0% 0%, 50% 100%, 100% 0%)")]
+        public void ClipPathLegalValues(string value)
+        {
+            var property = ParseDeclaration($"clip-path: {value}");
+
+            Assert.Equal("clip-path", property.Name);
+            Assert.IsType<ClipPathProperty>(property);
+            Assert.True(property.HasValue);
+        }
+
+        [Theory]
+        [InlineData("clip-path: banana")]
+        [InlineData("clip-path: circle(-5px)")]            // negative radius
+        [InlineData("clip-path: ellipse(50%)")]            // ellipse needs two radii
+        [InlineData("clip-path: ellipse(10% 20% 30%)")]    // ...not three
+        [InlineData("clip-path: inset()")]                 // needs at least one offset
+        [InlineData("clip-path: inset(10px round)")]       // round needs a radius
+        [InlineData("clip-path: inset(1px 2px 3px 4px 5px)")]
+        [InlineData("clip-path: polygon(0 0, 100%)")]      // incomplete vertex
+        [InlineData("clip-path: polygon()")]               // needs at least one vertex
+        [InlineData("clip-path: circle(at)")]              // at needs a position
+        [InlineData("clip-path: circle(50% 50%)")]         // circle takes one radius, not two
+        public void ClipPathIllegalValues(string snippet)
+        {
+            var property = ParseDeclaration(snippet);
+
+            Assert.IsType<ClipPathProperty>(property);
+            Assert.False(property.HasValue);
+        }
+
+        [Fact]
+        public void ClipPathPreservesAuthoredText()
+        {
+            var property = ParseDeclaration("clip-path: polygon(0 0, 100% 0, 50% 100%)");
+
+            Assert.Equal("polygon(0 0, 100% 0, 50% 100%)", property.Value);
+        }
+    }
+}

--- a/src/ExCSS/Enumerations/FunctionNames.cs
+++ b/src/ExCSS/Enumerations/FunctionNames.cs
@@ -11,6 +11,10 @@
         public static readonly string Hsl = "hsl";
         public static readonly string Hsla = "hsla";
         public static readonly string Rect = "rect";
+        public static readonly string Polygon = "polygon";
+        public static readonly string Circle = "circle";
+        public static readonly string Ellipse = "ellipse";
+        public static readonly string Inset = "inset";
         public static readonly string Attr = "attr";
         public static readonly string LinearGradient = "linear-gradient";
         public static readonly string RadialGradient = "radial-gradient";

--- a/src/ExCSS/Factories/PropertyFactory.cs
+++ b/src/ExCSS/Factories/PropertyFactory.cs
@@ -309,6 +309,7 @@ namespace ExCSS
             AddLonghand(PropertyNames.TextTransform, () => new TextTransformProperty());
             AddLonghand(PropertyNames.TextShadow, () => new TextShadowProperty(), true);
             AddLonghand(PropertyNames.Transform, () => new TransformProperty(), true);
+            AddLonghand(PropertyNames.ClipPath, () => new ClipPathProperty(), true);
             AddLonghand(PropertyNames.TransformOrigin, () => new TransformOriginProperty(), true);
             AddLonghand(PropertyNames.TransformStyle, () => new TransformStyleProperty());
 

--- a/src/ExCSS/StyleProperties/Visibility/ClipPathProperty.cs
+++ b/src/ExCSS/StyleProperties/Visibility/ClipPathProperty.cs
@@ -1,0 +1,14 @@
+﻿namespace ExCSS
+{
+    internal sealed class ClipPathProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = new ClipPathValueConverter().OrDefault();
+
+        internal ClipPathProperty()
+            : base(PropertyNames.ClipPath, PropertyFlags.Animatable)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/ValueConverters/ClipPathValueConverter.cs
+++ b/src/ExCSS/ValueConverters/ClipPathValueConverter.cs
@@ -1,0 +1,212 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// Validates a <c>clip-path</c> value (CSS Masking 1 §5.1): the keyword <c>none</c> or a
+    /// <c>&lt;basic-shape&gt;</c> - <c>polygon()</c>, <c>inset()</c>, <c>circle()</c> or <c>ellipse()</c>
+    /// (CSS Shapes 1 §3). The authored text is preserved. The <c>&lt;geometry-box&gt;</c> and
+    /// <c>&lt;url&gt;</c> forms are out of scope here.
+    /// </summary>
+    internal sealed class ClipPathValueConverter : IValueConverter
+    {
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            var tokens = value.Where(t => t.Type != TokenType.Whitespace).ToArray();
+
+            if (tokens.Length == 1 && tokens[0].Type == TokenType.Ident && tokens[0].Data.Isi(Keywords.None))
+                return new ClipPathValue(value);
+
+            return IsBasicShape(tokens) ? new ClipPathValue(value) : null;
+        }
+
+        public IPropertyValue Construct(Property[] properties)
+        {
+            return properties.Guard<ClipPathValue>();
+        }
+
+        private static bool IsBasicShape(IReadOnlyList<Token> tokens)
+        {
+            if (tokens.Count != 1 || tokens[0] is not FunctionToken function) return false;
+
+            var args = function.ArgumentTokens.Where(t => t.Type != TokenType.Whitespace).ToArray();
+
+            if (function.Data.Isi(FunctionNames.Polygon)) return IsPolygon(args);
+            if (function.Data.Isi(FunctionNames.Inset)) return IsInset(args);
+            if (function.Data.Isi(FunctionNames.Circle)) return IsCircle(args);
+            if (function.Data.Isi(FunctionNames.Ellipse)) return IsEllipse(args);
+
+            return false;
+        }
+
+        // polygon( <fill-rule>? , [ <length-percentage> <length-percentage> ]# )
+        private static bool IsPolygon(IReadOnlyList<Token> args)
+        {
+            var groups = SplitByComma(args);
+            if (groups == null || groups.Count == 0) return false;
+
+            var first = 0;
+
+            if (groups[0].Count == 1 && IsFillRule(groups[0][0]))
+                first = 1;
+
+            if (first >= groups.Count) return false;
+
+            for (var i = first; i < groups.Count; i++)
+            {
+                var group = groups[i];
+                if (group.Count != 2 || !IsLengthPercentage(group[0]) || !IsLengthPercentage(group[1]))
+                    return false;
+            }
+
+            return true;
+        }
+
+        // inset( <length-percentage>{1,4} [ round <border-radius> ]? )
+        private static bool IsInset(IReadOnlyList<Token> args)
+        {
+            if (args.Count == 0) return false;
+
+            var roundIndex = -1;
+            for (var i = 0; i < args.Count; i++)
+            {
+                if (args[i].Type == TokenType.Ident && args[i].Data.Isi(Keywords.Round))
+                {
+                    roundIndex = i;
+                    break;
+                }
+            }
+
+            var lengths = roundIndex >= 0 ? args.Take(roundIndex).ToArray() : args.ToArray();
+            var roundCount = roundIndex >= 0 ? args.Count - roundIndex - 1 : 0;
+
+            if (lengths.Length is < 1 or > 4 || lengths.Any(t => !IsLengthPercentage(t))) return false;
+
+            // "round" must be followed by a radius, which must itself be all length-percentages.
+            if (roundIndex >= 0)
+            {
+                if (roundCount == 0) return false;
+                if (args.Skip(roundIndex + 1).Any(t => !IsLengthPercentage(t))) return false;
+            }
+
+            return true;
+        }
+
+        // circle( <shape-radius>? [ at <position> ]? )
+        private static bool IsCircle(IReadOnlyList<Token> args)
+        {
+            if (!SplitAt(args, out var radius, out var position)) return false;
+            return radius.Count switch
+            {
+                0 => true,
+                1 => IsShapeRadius(radius[0]),
+                _ => false
+            } && IsPosition(position);
+        }
+
+        // ellipse( [ <shape-radius>{2} ]? [ at <position> ]? )
+        private static bool IsEllipse(IReadOnlyList<Token> args)
+        {
+            if (!SplitAt(args, out var radius, out var position)) return false;
+            return radius.Count switch
+            {
+                0 => true,
+                2 => IsShapeRadius(radius[0]) && IsShapeRadius(radius[1]),
+                _ => false
+            } && IsPosition(position);
+        }
+
+        // Splits the arguments at a standalone "at" ident. Returns false when "at" has nothing after it.
+        private static bool SplitAt(IReadOnlyList<Token> args, out IReadOnlyList<Token> before,
+            out IReadOnlyList<Token> after)
+        {
+            for (var i = 0; i < args.Count; i++)
+            {
+                if (args[i].Type == TokenType.Ident && args[i].Data.Isi(Keywords.At))
+                {
+                    before = args.Take(i).ToArray();
+                    after = args.Skip(i + 1).ToArray();
+                    return after.Count > 0;
+                }
+            }
+
+            before = args;
+            after = new Token[0];
+            return true;
+        }
+
+        // A permissive <position>: nothing (absent), or 1-4 tokens each an edge/center keyword or a
+        // length-percentage. Absent is valid (the caller only reaches here with the post-"at" tokens).
+        private static bool IsPosition(IReadOnlyList<Token> tokens)
+        {
+            if (tokens.Count == 0) return true;
+            if (tokens.Count > 4) return false;
+
+            return tokens.All(t => IsPositionKeyword(t) || IsLengthPercentage(t));
+        }
+
+        private static bool IsPositionKeyword(Token token)
+        {
+            if (token.Type != TokenType.Ident) return false;
+            return token.Data.Isi(Keywords.Left) || token.Data.Isi(Keywords.Right) ||
+                   token.Data.Isi(Keywords.Top) || token.Data.Isi(Keywords.Bottom) ||
+                   token.Data.Isi(Keywords.Center);
+        }
+
+        private static bool IsShapeRadius(Token token)
+        {
+            if (token.Type == TokenType.Ident)
+                return token.Data.Isi(Keywords.ClosestSide) || token.Data.Isi(Keywords.FarthestSide);
+
+            // A <shape-radius> is a non-negative <length-percentage> (CSS Shapes 1 §3.2).
+            if (token is UnitToken { Value: < 0f } or NumberToken { Value: < 0f }) return false;
+
+            return IsLengthPercentage(token);
+        }
+
+        private static bool IsFillRule(Token token) =>
+            token.Type == TokenType.Ident && (token.Data.Isi(Keywords.Nonzero) || token.Data.Isi(Keywords.Evenodd));
+
+        private static bool IsLengthPercentage(Token token) =>
+            token.Type is TokenType.Dimension or TokenType.Percentage || token is NumberToken { Value: 0f };
+
+        private static List<List<Token>> SplitByComma(IReadOnlyList<Token> tokens)
+        {
+            var groups = new List<List<Token>>();
+            var current = new List<Token>();
+
+            foreach (var token in tokens)
+            {
+                if (token.Type == TokenType.Comma)
+                {
+                    groups.Add(current);
+                    current = new List<Token>();
+                }
+                else
+                {
+                    current.Add(token);
+                }
+            }
+
+            groups.Add(current);
+
+            // A leading, trailing or doubled comma leaves an empty group - always malformed here.
+            return tokens.Count > 0 && groups.Any(g => g.Count == 0) ? null : groups;
+        }
+
+        private sealed class ClipPathValue : IPropertyValue
+        {
+            public ClipPathValue(IEnumerable<Token> tokens)
+            {
+                Original = new TokenValue(tokens);
+            }
+
+            public string CssText => Original.Text;
+
+            public TokenValue Original { get; }
+
+            public TokenValue ExtractFor(string name) => Original;
+        }
+    }
+}


### PR DESCRIPTION
### Feature

Adds `clip-path` ([CSS Masking 1 §5.1](https://www.w3.org/TR/css-masking-1/#the-clip-path)) with the `<basic-shape>` functions ([CSS Shapes 1 §3](https://www.w3.org/TR/css-shapes-1/#basic-shape-functions)):

```css
clip-path: none;
clip-path: circle(50% at center);
clip-path: ellipse(closest-side farthest-side at 30% 40%);
clip-path: inset(10px 20px round 5px);
clip-path: polygon(evenodd, 0 0, 100% 0, 50% 100%);
```

### Implementation

`ClipPathValueConverter` accepts `none` or one of `polygon()` / `inset()` / `circle()` / `ellipse()`, validating each function's argument grammar and preserving the authored text:

- **polygon** — optional `<fill-rule>` (`nonzero`/`evenodd`), then a comma list of `<length-percentage> <length-percentage>` vertices
- **inset** — 1–4 `<length-percentage>` offsets, optional `round <border-radius>`
- **circle** — optional `<shape-radius>` (a non-negative length-percentage, `closest-side`, or `farthest-side`), optional `at <position>`
- **ellipse** — same, with two radii

Negative radii, the wrong number of radii, incomplete vertices, a bare `round`, and unknown values are all rejected.

The `<geometry-box>` and `url()` reference-box forms are out of scope.

### Tests

29 cases in `PropertyTests/ClipPathProperty.cs`: 16 legal shapes, 11 malformed (`banana`, `circle(-5px)`, `ellipse(50%)`, three-radius ellipse, `inset()`, `inset(10px round)`, five-offset inset, incomplete polygon vertex, empty polygon, `circle(at)`, two-radius circle), and a text-preservation check.

The legal and illegal cases fail on `master` (the property is unknown). The full suite (1263 existing tests) stays green, and all seven target frameworks build with no new warnings.
