### PR TITLE
Accept vertical-first edge offsets in background-position

### DIFF
--- a/src/ExCSS.Tests/PropertyTests/BackgroundProperty.cs
+++ b/src/ExCSS.Tests/PropertyTests/BackgroundProperty.cs
@@ -360,6 +360,36 @@
             Assert.Equal("right 20px bottom 20px", concrete.Value);
         }
 
+        [Theory]
+        // The 3/4-value edge-offset syntax uses "&&", so the vertical component may come first, mirroring
+        // the horizontal-first form above (CSS Backgrounds 3 3.6).
+        [InlineData("bottom 10px right 20px")]
+        [InlineData("bottom 10px right")]
+        [InlineData("bottom right 20px")]
+        [InlineData("bottom 10px center")]
+        [InlineData("center bottom 10px")]
+        public void BackgroundPositionVerticalFirstEdgeOffsetsLegal(string value)
+        {
+            var property = ParseDeclaration($"background-position: {value}");
+
+            Assert.IsType<BackgroundPositionProperty>(property);
+            Assert.True(property.HasValue);
+        }
+
+        [Theory]
+        // Two components on the same axis remain invalid regardless of order.
+        [InlineData("background-position: left right")]
+        [InlineData("background-position: top bottom")]
+        [InlineData("background-position: bottom 10px top")]
+        [InlineData("background-position: left 10px right 20px")]
+        public void BackgroundPositionSameAxisTwiceIllegal(string snippet)
+        {
+            var property = ParseDeclaration(snippet);
+
+            Assert.IsType<BackgroundPositionProperty>(property);
+            Assert.False(property.HasValue);
+        }
+
         [Fact]
         public void BackgroundPositionLengthLengthCenterMultipleLegal()
         {

--- a/src/ExCSS/Model/Converters.cs
+++ b/src/ExCSS/Model/Converters.cs
@@ -100,7 +100,13 @@ namespace ExCSS
                 WithOrder(v, h)).Or(
                 WithOrder(hi, vi, LengthOrPercentConverter)).Or(
                 WithOrder(hi, LengthOrPercentConverter, vi)).Or(
-                WithOrder(hi, LengthOrPercentConverter, vi, LengthOrPercentConverter));
+                WithOrder(hi, LengthOrPercentConverter, vi, LengthOrPercentConverter)).Or(
+                // The 3/4-value edge-offset syntax is "&&", so the vertical component may come first too
+                // (CSS Backgrounds 3 3.6): "bottom 10px right", "bottom right 20px",
+                // "bottom 10px right 20px". These mirror the horizontal-first forms above.
+                WithOrder(vi, hi, LengthOrPercentConverter)).Or(
+                WithOrder(vi, LengthOrPercentConverter, hi)).Or(
+                WithOrder(vi, LengthOrPercentConverter, hi, LengthOrPercentConverter));
         });
 
         public static readonly IValueConverter AttrConverter = new FunctionValueConverter(


### PR DESCRIPTION
### Problem

The 3-/4-value `background-position` syntax positions each axis by an edge keyword plus an optional offset, combined with `&&` — so the two axes may appear in **either order** ([CSS Backgrounds 3 §3.6](https://www.w3.org/TR/css-backgrounds-3/#background-position)):

> `[ center | [ left | right ] <length-percentage>? ] && [ center | [ top | bottom ] <length-percentage>? ]`

The horizontal-first forms work, but their vertical-first mirrors are rejected:

```css
background-position: right 20px bottom 10px;  /* accepted */
background-position: bottom 10px right 20px;  /* rejected */
background-position: bottom 10px right;       /* rejected */
background-position: bottom right 20px;       /* rejected */
```

`PointConverter` has `WithOrder(hi, vi, …)` / `WithOrder(hi, <lp>, vi, …)` for the horizontal-first cases but no vertical-first equivalents.

### Fix

Add the three mirrored `WithOrder` cases (`vi hi <lp>`, `vi <lp> hi`, `vi <lp> hi <lp>`) after the existing horizontal-first ones.

Two components on the same axis stay invalid — `left right`, `top bottom`, `bottom 10px top`, `left 10px right 20px` are all still rejected.

### Tests

9 cases in `PropertyTests/BackgroundProperty.cs`: 5 vertical-first legal forms and 4 same-axis-twice illegal ones. The 5 legal cases fail on `master`; the illegal guards pass both ways. The full suite (1263 existing tests) stays green, and all seven target frameworks build with no new warnings.

`PointConverter` also backs `radial-gradient`/`conic-gradient` positions, which gain the same symmetry.
