### PR TITLE
Add custom properties and var()

### DIFF
--- a/src/ExCSS.Tests/PropertyTests/CustomPropertyTests.cs
+++ b/src/ExCSS.Tests/PropertyTests/CustomPropertyTests.cs
@@ -1,0 +1,98 @@
+using System.Linq;
+using Xunit;
+
+namespace ExCSS.Tests.PropertyTests
+{
+    public class CustomPropertyTests : CssConstructionFunctions
+    {
+        private static StyleDeclaration Style(string declarations)
+        {
+            var sheet = ParseStyleSheet(".a { " + declarations + " }");
+            return ((StyleRule)sheet.Rules[0]).Style;
+        }
+
+        [Theory]
+        // A custom property (CSS Variables 1 2) is a first-class declaration - no unknown-declaration flag
+        // needed - and its value is preserved verbatim.
+        [InlineData("--my-color: red", "--my-color", "red")]
+        [InlineData("--gap: 10px", "--gap", "10px")]
+        [InlineData("--ratio: 16 / 9", "--ratio", "16/9")]
+        [InlineData("--x: anything you like !", "--x", "anything you like !")]
+        public void CustomPropertyIsStored(string declaration, string name, string value)
+        {
+            var style = Style(declaration);
+
+            Assert.Equal(1, style.Length);
+            Assert.Equal(name, style[0]);
+            Assert.Equal(value, style[name]);
+        }
+
+        [Fact]
+        public void CustomPropertyProducesCustomPropertyType()
+        {
+            var property = ParseDeclaration("--main: blue");
+
+            Assert.IsType<CustomProperty>(property);
+            Assert.Equal("--main", property.Name);
+            Assert.True(property.HasValue);
+        }
+
+        [Theory]
+        // "--" alone (fewer than one code point after the dashes) is reserved, not a custom property.
+        [InlineData("-")]
+        [InlineData("--")]
+        public void NotACustomPropertyName(string name)
+        {
+            Assert.False(PropertyFactory.IsCustomPropertyName(name));
+        }
+
+        [Fact]
+        public void CustomPropertyNameCheck()
+        {
+            Assert.True(PropertyFactory.IsCustomPropertyName("--x"));
+            Assert.True(PropertyFactory.IsCustomPropertyName("--main-color"));
+        }
+
+        [Theory]
+        // A var() reference is accepted on any property and kept verbatim; the property's own grammar is
+        // not applied, since the referenced value is only known at cascade time (CSS Variables 1 3).
+        [InlineData("color: var(--c)", "color", "var(--c)")]
+        [InlineData("color: var(--c, blue)", "color", "var(--c, blue)")]
+        [InlineData("width: calc(var(--w) + 1px)", "width", "calc(var(--w) + 1px)")]
+        public void VarReferenceIsAcceptedOnLonghand(string declaration, string name, string value)
+        {
+            var style = Style(declaration);
+
+            Assert.Equal(value, style[name]);
+        }
+
+        [Theory]
+        // A shorthand whose value contains var() is kept whole - not sliced into longhands - because the
+        // reference can only be split after substitution (CSS Variables 1 3.2).
+        [InlineData("margin: var(--gap) 5px", "margin", "var(--gap) 5px")]
+        [InlineData("margin: var(--all)", "margin", "var(--all)")]
+        [InlineData("border: 1px solid var(--c)", "border", "1px solid var(--c)")]
+        public void VarBearingShorthandIsKeptWhole(string declaration, string name, string value)
+        {
+            var style = Style(declaration);
+
+            Assert.Equal(1, style.Length);
+            Assert.Equal(name, style[0]);
+            Assert.Equal(value, style[name]);
+            // The longhands are not populated at parse time.
+            Assert.Equal(string.Empty, style["margin-left"]);
+        }
+
+        [Fact]
+        public void CustomPropertyDashDashLexesAsOneIdent()
+        {
+            // Regression for the lexer: "--foo" must be a single ident, not '-' delimiter + "-foo".
+            var lexer = new Lexer(new TextSource("--foo")) { IsInValue = false };
+            var token = lexer.Get();
+
+            Assert.Equal(TokenType.Ident, token.Type);
+            Assert.Equal("--foo", token.Data);
+            Assert.Equal(TokenType.EndOfFile, lexer.Get().Type);
+        }
+    }
+}

--- a/src/ExCSS/Enumerations/FunctionNames.cs
+++ b/src/ExCSS/Enumerations/FunctionNames.cs
@@ -29,6 +29,7 @@
         public static readonly string Min = "min";
         public static readonly string Max = "max";
         public static readonly string Clamp = "clamp";
+        public static readonly string Var = "var";
         public static readonly string Toggle = "toggle";
         public static readonly string Translate = "translate";
         public static readonly string TranslateX = "translateX";

--- a/src/ExCSS/Extensions/ValueExtensions.cs
+++ b/src/ExCSS/Extensions/ValueExtensions.cs
@@ -483,6 +483,22 @@ namespace ExCSS
             return string.Join(string.Empty, value.Select(m => m.ToValue()));
         }
 
+        // Whether the value contains a call to the named function anywhere, including nested inside another
+        // function's arguments - e.g. var() inside calc(var(--x) + 1px).
+        public static bool ContainsFunction(this IEnumerable<Token> tokens, string functionName)
+        {
+            foreach (var token in tokens)
+            {
+                if (token is FunctionToken function &&
+                    (function.Data.Isi(functionName) || function.ArgumentTokens.ContainsFunction(functionName)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public static Color? ToColor(this IEnumerable<Token> value)
         {
             var element = value.OnlyOrDefault();

--- a/src/ExCSS/Factories/PropertyFactory.cs
+++ b/src/ExCSS/Factories/PropertyFactory.cs
@@ -365,7 +365,19 @@ namespace ExCSS
 
         public Property Create(string name)
         {
-            return CreateLonghand(name) ?? CreateShorthand(name);
+            return CreateLonghand(name) ?? CreateShorthand(name) ?? CreateCustomProperty(name);
+        }
+
+        private static Property CreateCustomProperty(string name)
+        {
+            return IsCustomPropertyName(name) ? new CustomProperty(name) : null;
+        }
+
+        // A custom property name is at least two dashes followed by at least one code point (CSS Custom
+        // Properties 1 2). "--" alone is reserved and not a valid custom property.
+        internal static bool IsCustomPropertyName(string name)
+        {
+            return name != null && name.Length > 2 && name[0] == '-' && name[1] == '-';
         }
 
         public Property CreateFont(string name)

--- a/src/ExCSS/Model/StyleDeclaration.cs
+++ b/src/ExCSS/Model/StyleDeclaration.cs
@@ -274,6 +274,16 @@ namespace ExCSS
 
         private void SetShorthand(ShorthandProperty shorthand)
         {
+            if (shorthand.DeclaredValue.Original.ContainsFunction(FunctionNames.Var))
+            {
+                // A var() reference can't be split into per-longhand slices here: the referenced custom
+                // property's value is only known per-element, at cascade time. Keep the shorthand
+                // declaration whole so substitution and expansion can happen once it is resolved (CSS
+                // Variables 1 3.2).
+                SetLonghand(shorthand);
+                return;
+            }
+
             var properties = PropertyFactory.Instance.CreateLonghandsFor(shorthand.Name);
             shorthand.Export(properties);
 

--- a/src/ExCSS/Parser/StylesheetComposer.cs
+++ b/src/ExCSS/Parser/StylesheetComposer.cs
@@ -680,8 +680,19 @@ namespace ExCSS
                         // Example 2: "margin: 5px !important; text-align:center; margin-left: 3px;";
                         if (sourceProperty is ShorthandProperty shorthandProperty)
                         {
-                            resolvedProperties = PropertyFactory.Instance.CreateLonghandsFor(shorthandProperty.Name);
-                            shorthandProperty.Export(resolvedProperties);
+                            if (shorthandProperty.DeclaredValue.Original.ContainsFunction(FunctionNames.Var))
+                            {
+                                // A var() reference can't be split into per-longhand slices at parse time -
+                                // the referenced custom property's value is only known per-element, at cascade
+                                // time. Keep the shorthand declaration whole so substitution and expansion can
+                                // happen once it is resolved (CSS Variables 1 3.2).
+                                resolvedProperties = new Property[] { shorthandProperty };
+                            }
+                            else
+                            {
+                                resolvedProperties = PropertyFactory.Instance.CreateLonghandsFor(shorthandProperty.Name);
+                                shorthandProperty.Export(resolvedProperties);
+                            }
                         }
 
                         foreach (var resolvedProperty in resolvedProperties)

--- a/src/ExCSS/StyleProperties/CustomProperty.cs
+++ b/src/ExCSS/StyleProperties/CustomProperty.cs
@@ -1,0 +1,16 @@
+﻿namespace ExCSS
+{
+    /// <summary>
+    /// A custom property - a declaration whose name begins with two dashes, e.g. <c>--main-color</c>
+    /// (CSS Custom Properties 1 §2). Its value has no fixed grammar, so it is stored as-is.
+    /// </summary>
+    internal sealed class CustomProperty : Property
+    {
+        internal CustomProperty(string name)
+            : base(name)
+        {
+        }
+
+        internal override IValueConverter Converter => Converters.Any;
+    }
+}

--- a/src/ExCSS/StyleProperties/Property.cs
+++ b/src/ExCSS/StyleProperties/Property.cs
@@ -22,7 +22,13 @@ namespace ExCSS
 
         internal bool TrySetValue(TokenValue newTokenValue)
         {
-            var value = Converter.Convert(newTokenValue ?? TokenValue.Initial);
+            var tokenValue = newTokenValue ?? TokenValue.Initial;
+
+            // A value containing var() can't be validated against this property's grammar here - the
+            // referenced custom property is only known per-element, at cascade time - so keep it verbatim
+            // via Converters.Any and let substitution resolve it later (CSS Variables 1 3).
+            var converter = tokenValue.ContainsFunction(FunctionNames.Var) ? Converters.Any : Converter;
+            var value = converter.Convert(tokenValue);
 
             if (value == null) return false;
             DeclaredValue = value;


### PR DESCRIPTION
### Feature

Custom properties and `var()` references ([CSS Custom Properties for Cascading Variables 1](https://www.w3.org/TR/css-variables-1/)):

```css
:root { --main-color: red; --gap: 10px; }
.a { color: var(--main-color); margin: var(--gap) 5px; }
```

On `master`: `--foo` lexes as a `-` delimiter plus `-foo`, custom-property declarations are dropped, and any value containing `var()` is rejected against the property's own grammar.

### Changes

- **Lexer** — a second `-` also begins an ident, so `--foo` is one ident (fixed in both the top-level `-` dispatch and `IdentStart`). `-->` still closes an HTML-style comment.
- **`CustomProperty`** — created for any `--*` name via `PropertyFactory.IsCustomPropertyName`, with its value kept verbatim (`Converters.Any`). `-` and `--` alone are reserved, not custom properties.
- **`var()` on any property** — `Property.TrySetValue` routes a value containing `var()` through `Converters.Any` rather than the property grammar, since the referenced value is only known per-element at cascade time ([§3](https://www.w3.org/TR/css-variables-1/#using-variables)).
- **`var()` in a shorthand** — kept whole rather than sliced into longhands (both `StyleDeclaration.SetShorthand` and the `StylesheetComposer` declaration path), because it can only be split after substitution ([§3.2](https://www.w3.org/TR/css-variables-1/#invalid-variables)). `margin: var(--gap) 5px` stays a single `margin` declaration.
- **`ValueExtensions.ContainsFunction`** — detects a function call anywhere, including nested (`var()` inside `calc()`).

### Scope: object model only, no substitution

This adds the **object model** for custom properties and `var()` — parsing, storage, and serialization — so a stylesheet round-trips faithfully and the declarations are queryable. It does **not** include a `var()` **substitution layer**: a property that references `var()` keeps its value verbatim (e.g. `color` reports `var(--c)`), it is not resolved to the referenced custom property's computed value.

Fully resolving a stylesheet — walking the cascade per element, substituting each `var()` reference (honouring fallbacks and the guaranteed-invalid / cyclic-reference rules of [CSS Variables 1 §3](https://www.w3.org/TR/css-variables-1/#using-variables)), then re-expanding any shorthand that contained one — is a separate cascade/computed-value layer that would have to be built on top of this. That layer is out of scope here; this PR is only the parser/object-model foundation it would consume.

If a substitution layer would be useful upstream, I'm happy to contribute one as a follow-up: this object model was extracted from a downstream renderer that already implements var() substitution on top of exactly these types, so a version that builds on this framework already exists and could be adapted.

### Tests

19 cases in `PropertyTests/CustomPropertyTests.cs`: custom properties stored verbatim (including odd values), the `CustomProperty` type, `IsCustomPropertyName` (rejecting `-`/`--`), `var()` accepted on longhands and inside `calc()`, var()-bearing shorthands kept whole with longhands unpopulated, and the `--foo`-is-one-ident lexer regression.

The full suite (1263 existing tests) stays green — the `--` lexer change and var() routing disturb nothing — and all seven target frameworks build with no new warnings.


