### PR TITLE
Add the @property at-rule

### DIFF
--- a/src/ExCSS.Tests/AtPropertyTests.cs
+++ b/src/ExCSS.Tests/AtPropertyTests.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+using Xunit;
+
+namespace ExCSS.Tests
+{
+    public class AtPropertyTests : CssConstructionFunctions
+    {
+        private static PropertyRule Parse(string source)
+        {
+            var sheet = ParseStyleSheet(source);
+            return (PropertyRule)sheet.Rules.First();
+        }
+
+        [Fact]
+        public void AtPropertyCapturesNameAndDescriptors()
+        {
+            var rule = Parse("@property --my-color { syntax: '<color>'; initial-value: red; inherits: false; }");
+
+            Assert.Equal(RuleType.Property, rule.Type);
+            Assert.Equal("--my-color", rule.Name);
+            Assert.Equal("\"<color>\"", rule.Syntax);
+            Assert.Equal("red", rule.InitialValue);
+            Assert.Equal("false", rule.Inherits);
+        }
+
+        [Fact]
+        public void AtPropertyRoundTrips()
+        {
+            var rule = Parse("@property --gap { syntax: '<length>'; initial-value: 0px; inherits: true; }");
+
+            Assert.Equal("@property --gap { syntax: \"<length>\"; initial-value: 0px; inherits: true }",
+                rule.ToCss());
+        }
+
+        [Fact]
+        public void AtPropertyWithUniversalSyntax()
+        {
+            var rule = Parse("@property --x { syntax: '*'; inherits: false; }");
+
+            Assert.Equal("\"*\"", rule.Syntax);
+            Assert.Equal("false", rule.Inherits);
+            Assert.Equal(string.Empty, rule.InitialValue);
+        }
+
+        [Fact]
+        public void AtPropertyIsExposedAsIPropertyRule()
+        {
+            var sheet = ParseStyleSheet("@property --c { syntax: '<color>'; inherits: false; }");
+            var rule = Assert.IsAssignableFrom<IPropertyRule>(sheet.Rules.First());
+
+            Assert.Equal("--c", rule.Name);
+        }
+
+        [Fact]
+        public void AtPropertyAmongOtherRules()
+        {
+            var sheet = ParseStyleSheet(
+                ".a { color: red } @property --c { syntax: '<color>'; inherits: false; } .b { color: blue }");
+
+            Assert.Equal(3, sheet.Rules.Length);
+            Assert.IsType<StyleRule>(sheet.Rules[0]);
+            Assert.IsType<PropertyRule>(sheet.Rules[1]);
+            Assert.IsType<StyleRule>(sheet.Rules[2]);
+        }
+    }
+}

--- a/src/ExCSS/Enumerations/PropertyNames.cs
+++ b/src/ExCSS/Enumerations/PropertyNames.cs
@@ -237,6 +237,10 @@
         public static readonly string Zoom = "zoom";
         public static readonly string UnicodeRange = "unicode-range";
         public static readonly string Src = "src";
+        // @property descriptors (CSS Properties and Values API 1 3)
+        public static readonly string Syntax = "syntax";
+        public static readonly string InitialValue = "initial-value";
+        public static readonly string Inherits = "inherits";
         public static readonly string ObjectFit = "object-fit";
         public static readonly string ObjectPosition = "object-position";
     }

--- a/src/ExCSS/Enumerations/RuleNames.cs
+++ b/src/ExCSS/Enumerations/RuleNames.cs
@@ -13,5 +13,6 @@
         public static readonly string Namespace = "namespace";
         public static readonly string Page = "page";
         public static readonly string Container = "container";
+        public static readonly string Property = "property";
     }
 }

--- a/src/ExCSS/Enumerations/RuleType.cs
+++ b/src/ExCSS/Enumerations/RuleType.cs
@@ -19,6 +19,7 @@
         FontFeatureValues,
         Viewport,
         RegionStyle,
-        Container
+        Container,
+        Property
     }
 }

--- a/src/ExCSS/Factories/PropertyFactory.cs
+++ b/src/ExCSS/Factories/PropertyFactory.cs
@@ -367,6 +367,20 @@ namespace ExCSS
             return _fonts.TryGetValue(name, out var propertyCreator) ? propertyCreator() : null;
         }
 
+        // The @property descriptors (syntax / initial-value / inherits). Their values have no fixed grammar
+        // - initial-value depends on the syntax, syntax is an arbitrary string - so each is stored raw via
+        // an UnknownProperty (Converters.Any).
+        public Property CreatePropertyDescriptor(string name)
+        {
+            return PropertyFactory.IsPropertyDescriptor(name) ? new UnknownProperty(name) : null;
+        }
+
+        private static bool IsPropertyDescriptor(string name)
+        {
+            return name.Is(PropertyNames.Syntax) || name.Is(PropertyNames.InitialValue) ||
+                   name.Is(PropertyNames.Inherits);
+        }
+
         public Property CreateViewport(string name)
         {
             var feature = MediaFeatureFactory.Instance.Create(name);

--- a/src/ExCSS/Parser/Lexer.cs
+++ b/src/ExCSS/Parser/Lexer.cs
@@ -94,10 +94,21 @@ namespace ExCSS
                         if (c1.IsNameStart()) return IdentStart(current);
                         if (c1 == Symbols.ReverseSolidus && !c2.IsLineBreak() && c2 != Symbols.EndOfFile)
                             return IdentStart(current);
-                        if (c1 != Symbols.Minus || c2 != Symbols.GreaterThan) return NewDelimiter(current);
 
-                        Advance(2);
-                        return NewCloseComment();
+                        if (c1 == Symbols.Minus)
+                        {
+                            // "-->" closes an HTML-style comment, but any other "--" starts an ident, so a
+                            // custom property name "--foo" (CSS Variables 1 2) is one ident.
+                            if (c2 == Symbols.GreaterThan)
+                            {
+                                Advance(2);
+                                return NewCloseComment();
+                            }
+
+                            return IdentStart(current);
+                        }
+
+                        return NewDelimiter(current);
                     }
 
                     Back();
@@ -451,7 +462,9 @@ namespace ExCSS
             if (current == Symbols.Minus)
             {
                 current = GetNext();
-                if (current.IsNameStart() || IsValidEscape(current))
+                // A second '-' also starts an ident, so a custom property name "--foo" (CSS Variables 1 2)
+                // lexes as one ident rather than a '-' delimiter followed by "-foo".
+                if (current.IsNameStart() || current == Symbols.Minus || IsValidEscape(current))
                 {
                     StringBuffer.Append(Symbols.Minus);
                     return IdentRest(current);

--- a/src/ExCSS/Parser/StylesheetComposer.cs
+++ b/src/ExCSS/Parser/StylesheetComposer.cs
@@ -39,6 +39,8 @@ namespace ExCSS
 
             if (token.Data.Is(RuleNames.Container)) return CreateContainer(token);
 
+            if (token.Data.Is(RuleNames.Property)) return CreateProperty(token);
+
             return token.Data.Is(RuleNames.Document) ? CreateDocument(token) : CreateUnknown(token);
         }
 
@@ -138,6 +140,28 @@ namespace ExCSS
             if (token.Type == TokenType.CurlyBracketOpen)
             {
                 var end = FillDeclarations(rule, PropertyFactory.Instance.CreateFont);
+                rule.StylesheetText = CreateView(start, end);
+                _nodes.Pop();
+                return rule;
+            }
+
+            _nodes.Pop();
+            return SkipDeclarations(token);
+        }
+
+        public Rule CreateProperty(Token current)
+        {
+            var rule = new PropertyRule(_parser);
+            var start = current.Position;
+            var token = NextToken();
+            _nodes.Push(rule);
+            ParseComments(ref token);
+            rule.Name = GetRuleName(ref token);
+            ParseComments(ref token);
+
+            if (token.Type == TokenType.CurlyBracketOpen)
+            {
+                var end = FillDeclarations(rule, PropertyFactory.Instance.CreatePropertyDescriptor);
                 rule.StylesheetText = CreateView(start, end);
                 _nodes.Pop();
                 return rule;

--- a/src/ExCSS/Rules/IPropertyRule.cs
+++ b/src/ExCSS/Rules/IPropertyRule.cs
@@ -1,0 +1,21 @@
+﻿namespace ExCSS
+{
+    /// <summary>
+    /// A registered custom property declared with an <c>@property</c> at-rule (CSS Properties and Values
+    /// API 1 §3). Exposes the three descriptors.
+    /// </summary>
+    public interface IPropertyRule : IRule, IProperties
+    {
+        /// <summary>The registered custom property name, e.g. <c>--my-color</c>.</summary>
+        string Name { get; set; }
+
+        /// <summary>The raw <c>syntax</c> descriptor value (e.g. <c>"&lt;color&gt;"</c> or <c>"*"</c>).</summary>
+        string Syntax { get; set; }
+
+        /// <summary>The raw <c>initial-value</c> descriptor value.</summary>
+        string InitialValue { get; set; }
+
+        /// <summary>The raw <c>inherits</c> descriptor value (<c>true</c> or <c>false</c>).</summary>
+        string Inherits { get; set; }
+    }
+}

--- a/src/ExCSS/Rules/PropertyRule.cs
+++ b/src/ExCSS/Rules/PropertyRule.cs
@@ -1,0 +1,50 @@
+﻿using System.IO;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// An <c>@property</c> at-rule (CSS Properties and Values API 1 §3): registers a typed custom property
+    /// with <c>syntax</c>, <c>initial-value</c> and <c>inherits</c> descriptors. The block is stored like a
+    /// <see cref="FontFaceRule"/>; the registered name (a dashed-ident such as <c>--my-color</c>) is
+    /// captured from the prelude like <see cref="KeyframesRule.Name"/>.
+    /// </summary>
+    internal sealed class PropertyRule : DeclarationRule, IPropertyRule
+    {
+        internal PropertyRule(StylesheetParser parser)
+            : base(RuleType.Property, RuleNames.Property, parser)
+        {
+        }
+
+        protected override Property CreateNewProperty(string name)
+        {
+            return PropertyFactory.Instance.CreatePropertyDescriptor(name);
+        }
+
+        public string Name { get; set; }
+
+        public string Syntax
+        {
+            get => GetValue(PropertyNames.Syntax);
+            set => SetValue(PropertyNames.Syntax, value);
+        }
+
+        public string InitialValue
+        {
+            get => GetValue(PropertyNames.InitialValue);
+            set => SetValue(PropertyNames.InitialValue, value);
+        }
+
+        public string Inherits
+        {
+            get => GetValue(PropertyNames.Inherits);
+            set => SetValue(PropertyNames.Inherits, value);
+        }
+
+        public override void ToCss(TextWriter writer, IStyleFormatter formatter)
+        {
+            var declarations = formatter.Declarations(Declarations.Where(d => d.HasValue).Select(d => d.ToCss(formatter)));
+            writer.Write(string.Concat("@property ", Name, " { ", declarations, " }"));
+        }
+    }
+}


### PR DESCRIPTION
### Feature

The `@property` at-rule ([CSS Properties and Values API 1 §3](https://www.w3.org/TR/css-properties-values-api-1/#at-property-rule)) registers a typed custom property:

```css
@property --my-color {
  syntax: '<color>';
  initial-value: red;
  inherits: false;
}
```

### Implementation

- **`PropertyRule`** — a `DeclarationRule` like `FontFaceRule`, with its `Name` captured from the prelude like `KeyframesRule`, and `Syntax` / `InitialValue` / `Inherits` accessors. Exposed as **`IPropertyRule`**.
- **`RuleNames.Property`**, **`RuleType.Property`**, and the three descriptor property names.
- **`PropertyFactory.CreatePropertyDescriptor`** — the descriptors have no fixed grammar (`initial-value` depends on `syntax`; `syntax` is an arbitrary string), so each is stored raw via `UnknownProperty`.
- **`StylesheetComposer.CreateProperty`** and its dispatch in `CreateAtRule`.

The rule round-trips: `@property --gap { syntax: "<length>"; initial-value: 0px; inherits: true }`.

### Scope: object model only, no registration/substitution

This adds the **object model** for the `@property` rule — parsing the prelude and the three descriptors into an inspectable, round-trippable `IPropertyRule`. It does **not** register the custom property or apply its `syntax`/`initial-value`/`inherits` semantics: nothing validates a `var()` substitution against the declared `syntax`, supplies the `initial-value` when a reference is invalid, or drives inheritance from `inherits`. Doing that is a computed-value/registered-property layer that would have to be built on top — the same substitution layer described in #211.

To be useful at all, this needs **#211 (custom properties and `var()`)**: `@property` registers a *custom* property, so without custom-property/`var()` support there is nothing for it to describe. #211 is the foundation; this is the `@property` rule on top of it, and a substitution/registration layer would sit above both. (This branch already carries the one `--` lexer change from #211 so it builds standalone — see Dependency below.)

If a registration/computed-value layer would be useful upstream, I'm happy to contribute one as a follow-up: this was extracted from a downstream renderer that already applies the `@property` descriptors (syntax-checked substitution, `initial-value` fallback, inheritance) on top of exactly these types, so a version that builds on this framework already exists and could be adapted.

### Dependency

The `--name` prelude requires `--` to lex as a single ident, which is the lexer fix from **"Add custom properties and var()"** (#211). This branch includes that one lexer change so it's self-contained; if #211 merges first, it rebases cleanly.

### Tests

5 tests in `AtPropertyTests.cs`: name/descriptor capture, round-trip, the universal `*` syntax, `IPropertyRule` exposure, and an `@property` among style rules.

The full suite (1263 existing tests) stays green, and all seven target frameworks build with no new warnings.

