### PR TITLE
Add calc()/min()/max()/clamp()

### DIFF
--- a/src/ExCSS.Tests/PropertyTests/CalcPropertyTests.cs
+++ b/src/ExCSS.Tests/PropertyTests/CalcPropertyTests.cs
@@ -1,0 +1,63 @@
+using Xunit;
+
+namespace ExCSS.Tests.PropertyTests
+{
+    public class CalcPropertyTests : CssConstructionFunctions
+    {
+        [Theory]
+        // calc()/min()/max()/clamp() (CSS Values 4 10) are accepted wherever a compatible numeric value is,
+        // and the authored text is preserved.
+        [InlineData("width: calc(100% - 20px)", "width")]
+        [InlineData("width: calc(50% + 2em)", "width")]
+        [InlineData("width: calc((100% - 20px) / 3)", "width")]
+        [InlineData("margin-top: calc(10px * 2)", "margin-top")]
+        [InlineData("width: min(100%, 500px)", "width")]
+        [InlineData("width: max(50%, 200px)", "width")]
+        [InlineData("width: clamp(200px, 50%, 500px)", "width")]
+        [InlineData("width: calc(min(10px, 5%) + 2px)", "width")]
+        public void CalcAcceptedInLengthContext(string declaration, string name)
+        {
+            var property = ParseDeclaration(declaration);
+
+            Assert.Equal(name, property.Name);
+            Assert.True(property.HasValue);
+        }
+
+        [Fact]
+        public void CalcPreservesAuthoredText()
+        {
+            var property = ParseDeclaration("width: calc(100% - 20px)");
+
+            Assert.Equal("calc(100% - 20px)", property.Value);
+        }
+
+        [Theory]
+        // A calc() also works in the angle context.
+        [InlineData("transform: rotate(calc(45deg * 2))")]
+        [InlineData("transform: rotate(calc(1turn / 4))")]
+        public void CalcAcceptedInAngleContext(string declaration)
+        {
+            var property = ParseDeclaration(declaration);
+
+            Assert.True(property.HasValue);
+        }
+
+        [Theory]
+        // Type-checking (CSS Values 4 10.10): dimensionally-inconsistent or malformed expressions are
+        // rejected.
+        [InlineData("width: calc(1px + 1s)")]      // length + time
+        [InlineData("width: calc(10px * 20px)")]   // length * length
+        [InlineData("width: calc(100% / 0)")]      // divide by a constant zero
+        [InlineData("width: calc(1px +1px)")]      // "+" needs whitespace on both sides
+        [InlineData("width: calc(5)")]             // bare number is not a length
+        [InlineData("width: calc()")]              // empty
+        [InlineData("width: clamp(1px, 2px)")]     // clamp() takes exactly three arguments
+        [InlineData("width: calc(1px + )")]        // missing operand
+        public void CalcRejectsInvalidExpressions(string declaration)
+        {
+            var property = ParseDeclaration(declaration);
+
+            Assert.False(property.HasValue);
+        }
+    }
+}

--- a/src/ExCSS/Calc/CalcCategory.cs
+++ b/src/ExCSS/Calc/CalcCategory.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// The CSS calc() type-checking category a (sub-)expression resolves to. A flags enum so that
+    /// <c>Length | Percentage</c> can represent the combined <c>&lt;length-percentage&gt;</c> type once a
+    /// length and a percentage have been added or subtracted together.
+    /// </summary>
+    [Flags]
+    internal enum CalcCategory
+    {
+        Number = 1,
+        Length = 2,
+        Percentage = 4,
+        LengthPercentage = Length | Percentage,
+        Angle = 8,
+        Time = 16,
+        Resolution = 32
+    }
+}

--- a/src/ExCSS/Calc/CalcNode.cs
+++ b/src/ExCSS/Calc/CalcNode.cs
@@ -1,0 +1,120 @@
+﻿using System.Collections.Generic;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// AST node for a parsed calc()/min()/max()/clamp() expression (CSS Values 4 §10).
+    /// </summary>
+    internal abstract class CalcNode
+    {
+    }
+
+    internal sealed class NumberCalcNode : CalcNode
+    {
+        public NumberCalcNode(double value)
+        {
+            Value = value;
+        }
+
+        public double Value { get; }
+    }
+
+    internal sealed class DimensionCalcNode : CalcNode
+    {
+        public DimensionCalcNode(double value, Length.Unit unit)
+        {
+            Value = value;
+            Unit = unit;
+        }
+
+        public double Value { get; }
+        public Length.Unit Unit { get; }
+    }
+
+    internal sealed class PercentageCalcNode : CalcNode
+    {
+        public PercentageCalcNode(double value)
+        {
+            Value = value;
+        }
+
+        public double Value { get; }
+    }
+
+    internal sealed class AngleCalcNode : CalcNode
+    {
+        public AngleCalcNode(double value, Angle.Unit unit)
+        {
+            Value = value;
+            Unit = unit;
+        }
+
+        public double Value { get; }
+        public Angle.Unit Unit { get; }
+    }
+
+    internal sealed class TimeCalcNode : CalcNode
+    {
+        public TimeCalcNode(double value, Time.Unit unit)
+        {
+            Value = value;
+            Unit = unit;
+        }
+
+        public double Value { get; }
+        public Time.Unit Unit { get; }
+    }
+
+    internal sealed class ResolutionCalcNode : CalcNode
+    {
+        public ResolutionCalcNode(double value, Resolution.Unit unit)
+        {
+            Value = value;
+            Unit = unit;
+        }
+
+        public double Value { get; }
+        public Resolution.Unit Unit { get; }
+    }
+
+    /// <summary>A leading unary sign directly before a parenthesized group or a nested function call.</summary>
+    internal sealed class UnaryCalcNode : CalcNode
+    {
+        public UnaryCalcNode(bool negative, CalcNode operand)
+        {
+            Negative = negative;
+            Operand = operand;
+        }
+
+        public bool Negative { get; }
+        public CalcNode Operand { get; }
+    }
+
+    /// <summary>A binary <c>+</c>/<c>-</c>/<c>*</c>/<c>/</c> operation.</summary>
+    internal sealed class BinaryCalcNode : CalcNode
+    {
+        public BinaryCalcNode(char op, CalcNode left, CalcNode right)
+        {
+            Operator = op;
+            Left = left;
+            Right = right;
+        }
+
+        public char Operator { get; }
+        public CalcNode Left { get; }
+        public CalcNode Right { get; }
+    }
+
+    /// <summary>A <c>min()</c>, <c>max()</c>, or <c>clamp()</c> call over its comma-separated arguments.</summary>
+    internal sealed class CallCalcNode : CalcNode
+    {
+        public CallCalcNode(string name, IReadOnlyList<CalcNode> arguments)
+        {
+            Name = name;
+            Arguments = arguments;
+        }
+
+        public string Name { get; }
+        public IReadOnlyList<CalcNode> Arguments { get; }
+    }
+}

--- a/src/ExCSS/Calc/CalcParser.cs
+++ b/src/ExCSS/Calc/CalcParser.cs
@@ -1,0 +1,264 @@
+﻿using System.Collections.Generic;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// Recursive-descent parser for calc()/min()/max()/clamp() expressions (CSS Values 4 §10). Grammar:
+    /// <c>&lt;calc-sum&gt; := &lt;calc-product&gt; (('+'|'-') &lt;calc-product&gt;)*</c>,
+    /// <c>&lt;calc-product&gt; := &lt;calc-value&gt; (('*'|'/') &lt;calc-value&gt;)*</c>,
+    /// <c>&lt;calc-value&gt; := &lt;number&gt; | &lt;dimension&gt; | &lt;percentage&gt; | '(' &lt;calc-sum&gt; ')' | &lt;nested-call&gt; | &lt;unary-sign&gt; &lt;calc-value&gt;</c>.
+    /// Binary <c>+</c>/<c>-</c> require whitespace on both sides; <c>*</c>/<c>/</c> do not. Returns null on
+    /// any grammar violation.
+    /// </summary>
+    internal static class CalcParser
+    {
+        public static CalcNode Parse(FunctionToken function)
+        {
+            var name = function.Data;
+
+            if (name.Isi(FunctionNames.Calc))
+            {
+                var tokens = new List<Token>(function.ArgumentTokens);
+                var pos = 0;
+                var node = ParseSum(tokens, ref pos);
+                if (node == null) return null;
+
+                SkipWhitespace(tokens, ref pos);
+                return pos == tokens.Count ? node : null;
+            }
+
+            if (name.Isi(FunctionNames.Min) || name.Isi(FunctionNames.Max))
+            {
+                var args = ParseCommaSeparatedSums(function, out var groupCount);
+                return groupCount >= 1 && args != null
+                    ? new CallCalcNode(name.Isi(FunctionNames.Min) ? FunctionNames.Min : FunctionNames.Max, args)
+                    : null;
+            }
+
+            if (name.Isi(FunctionNames.Clamp))
+            {
+                var args = ParseCommaSeparatedSums(function, out var groupCount);
+                return groupCount == 3 && args != null ? new CallCalcNode(FunctionNames.Clamp, args) : null;
+            }
+
+            return null;
+        }
+
+        public static bool IsCalcFamily(string name)
+        {
+            return name.Isi(FunctionNames.Calc) || name.Isi(FunctionNames.Min) ||
+                   name.Isi(FunctionNames.Max) || name.Isi(FunctionNames.Clamp);
+        }
+
+        private static List<CalcNode> ParseCommaSeparatedSums(FunctionToken function, out int groupCount)
+        {
+            var groups = function.ArgumentTokens.ToList();
+            groupCount = groups.Count;
+
+            var args = new List<CalcNode>(groups.Count);
+
+            foreach (var group in groups)
+            {
+                if (group.Count == 0) return null;
+
+                var pos = 0;
+                var node = ParseSum(group, ref pos);
+                if (node == null) return null;
+
+                SkipWhitespace(group, ref pos);
+                if (pos != group.Count) return null;
+
+                args.Add(node);
+            }
+
+            return args;
+        }
+
+        private static CalcNode ParseSum(List<Token> tokens, ref int pos)
+        {
+            var left = ParseProduct(tokens, ref pos);
+            if (left == null) return null;
+
+            while (true)
+            {
+                var beforeWhitespace = pos;
+                SkipWhitespace(tokens, ref pos);
+                var sawWhitespaceBefore = pos != beforeWhitespace;
+
+                if (pos >= tokens.Count || tokens[pos].Type != TokenType.Delim ||
+                    (tokens[pos].Data != "+" && tokens[pos].Data != "-"))
+                {
+                    pos = beforeWhitespace;
+                    break;
+                }
+
+                // Binary +/- must have whitespace on both sides; without it this can't be a valid binary
+                // operator here (an attached sign is already merged into the adjacent numeric token).
+                if (!sawWhitespaceBefore) return null;
+
+                var op = tokens[pos].Data[0];
+                pos++;
+
+                var afterOp = pos;
+                SkipWhitespace(tokens, ref pos);
+                if (pos == afterOp) return null;
+
+                var right = ParseProduct(tokens, ref pos);
+                if (right == null) return null;
+
+                left = new BinaryCalcNode(op, left, right);
+            }
+
+            return left;
+        }
+
+        private static CalcNode ParseProduct(List<Token> tokens, ref int pos)
+        {
+            var left = ParseValue(tokens, ref pos);
+            if (left == null) return null;
+
+            while (true)
+            {
+                var save = pos;
+                SkipWhitespace(tokens, ref pos);
+
+                if (pos >= tokens.Count || tokens[pos].Type != TokenType.Delim ||
+                    (tokens[pos].Data != "*" && tokens[pos].Data != "/"))
+                {
+                    pos = save;
+                    break;
+                }
+
+                var op = tokens[pos].Data[0];
+                pos++;
+                SkipWhitespace(tokens, ref pos);
+
+                var right = ParseValue(tokens, ref pos);
+                if (right == null) return null;
+
+                left = new BinaryCalcNode(op, left, right);
+            }
+
+            return left;
+        }
+
+        private static CalcNode ParseValue(List<Token> tokens, ref int pos)
+        {
+            SkipWhitespace(tokens, ref pos);
+            if (pos >= tokens.Count) return null;
+
+            var token = tokens[pos];
+
+            switch (token.Type)
+            {
+                case TokenType.Number:
+                    pos++;
+                    return new NumberCalcNode(((NumberToken) token).Value);
+
+                case TokenType.Percentage:
+                    pos++;
+                    return new PercentageCalcNode(((UnitToken) token).Value);
+
+                case TokenType.Dimension:
+                    return ParseDimension((UnitToken) token, tokens, ref pos);
+
+                case TokenType.RoundBracketOpen:
+                {
+                    pos++;
+                    var inner = ParseSum(tokens, ref pos);
+                    if (inner == null) return null;
+
+                    SkipWhitespace(tokens, ref pos);
+                    if (pos >= tokens.Count || tokens[pos].Type != TokenType.RoundBracketClose) return null;
+                    pos++;
+                    return inner;
+                }
+
+                case TokenType.Delim when token.Data == "+" || token.Data == "-":
+                {
+                    var negative = token.Data == "-";
+                    pos++;
+
+                    // A unary sign must be immediately followed by a parenthesized group or a nested
+                    // function call (a signed number/dimension is already a single token from the lexer).
+                    if (pos >= tokens.Count ||
+                        (tokens[pos].Type != TokenType.RoundBracketOpen && tokens[pos].Type != TokenType.Function))
+                    {
+                        return null;
+                    }
+
+                    var operand = ParseValue(tokens, ref pos);
+                    return operand == null ? null : new UnaryCalcNode(negative, operand);
+                }
+
+                case TokenType.Function:
+                {
+                    var nested = (FunctionToken) token;
+                    if (!IsCalcFamily(nested.Data)) return null;
+                    pos++;
+                    return Parse(nested);
+                }
+
+                default:
+                    return null;
+            }
+        }
+
+        private static CalcNode ParseDimension(UnitToken token, List<Token> tokens, ref int pos)
+        {
+            var lengthUnit = Length.GetUnit(token.Unit);
+            if (IsSupportedLengthUnit(lengthUnit))
+            {
+                pos++;
+                return new DimensionCalcNode(token.Value, lengthUnit);
+            }
+
+            var angleUnit = Angle.GetUnit(token.Unit);
+            if (angleUnit != Angle.Unit.None)
+            {
+                pos++;
+                return new AngleCalcNode(token.Value, angleUnit);
+            }
+
+            var timeUnit = Time.GetUnit(token.Unit);
+            if (timeUnit != Time.Unit.None)
+            {
+                pos++;
+                return new TimeCalcNode(token.Value, timeUnit);
+            }
+
+            var resolutionUnit = Resolution.GetUnit(token.Unit);
+            if (resolutionUnit != Resolution.Unit.None)
+            {
+                pos++;
+                return new ResolutionCalcNode(token.Value, resolutionUnit);
+            }
+
+            return null;
+        }
+
+        private static bool IsSupportedLengthUnit(Length.Unit unit)
+        {
+            switch (unit)
+            {
+                case Length.Unit.Em:
+                case Length.Unit.Rem:
+                case Length.Unit.Ex:
+                case Length.Unit.Px:
+                case Length.Unit.Mm:
+                case Length.Unit.Cm:
+                case Length.Unit.In:
+                case Length.Unit.Pt:
+                case Length.Unit.Pc:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static void SkipWhitespace(List<Token> tokens, ref int pos)
+        {
+            while (pos < tokens.Count && tokens[pos].Type == TokenType.Whitespace) pos++;
+        }
+    }
+}

--- a/src/ExCSS/Calc/CalcTypeChecker.cs
+++ b/src/ExCSS/Calc/CalcTypeChecker.cs
@@ -1,0 +1,153 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// Implements CSS calc()'s type-checking rules (CSS Values 4 §10.10) over a parsed
+    /// <see cref="CalcNode"/> tree, returning the resolved category or null when the expression is
+    /// dimensionally inconsistent (e.g. adding a length to a time, or dividing by something that isn't a
+    /// number). Also folds pure-number subtrees, which is what makes a constant divide-by-zero divisor
+    /// detectable here.
+    /// </summary>
+    internal static class CalcTypeChecker
+    {
+        public static CalcCategory? Check(CalcNode node)
+        {
+            switch (node)
+            {
+                case NumberCalcNode _:
+                    return CalcCategory.Number;
+
+                case DimensionCalcNode _:
+                    return CalcCategory.Length;
+
+                case PercentageCalcNode _:
+                    return CalcCategory.Percentage;
+
+                case AngleCalcNode _:
+                    return CalcCategory.Angle;
+
+                case TimeCalcNode _:
+                    return CalcCategory.Time;
+
+                case ResolutionCalcNode _:
+                    return CalcCategory.Resolution;
+
+                case UnaryCalcNode unary:
+                    return Check(unary.Operand);
+
+                case BinaryCalcNode binary when binary.Operator == '+' || binary.Operator == '-':
+                    return Combine(Check(binary.Left), Check(binary.Right));
+
+                case BinaryCalcNode binary when binary.Operator == '*':
+                {
+                    var left = Check(binary.Left);
+                    var right = Check(binary.Right);
+                    if (left == null || right == null) return null;
+                    if (left == CalcCategory.Number) return right;
+                    if (right == CalcCategory.Number) return left;
+                    return null;
+                }
+
+                case BinaryCalcNode binary when binary.Operator == '/':
+                {
+                    var left = Check(binary.Left);
+                    var right = Check(binary.Right);
+                    if (left == null || right != CalcCategory.Number) return null;
+
+                    // A Number-category subtree is built entirely from number leaves, so it always folds -
+                    // this is what lets a constant divide-by-zero be rejected here rather than deferred.
+                    var divisor = FoldNumber(binary.Right);
+                    return divisor == null || divisor.Value == 0d ? (CalcCategory?) null : left;
+                }
+
+                case CallCalcNode call:
+                {
+                    CalcCategory? combined = null;
+                    foreach (var argument in call.Arguments)
+                    {
+                        var category = Check(argument);
+                        if (category == null) return null;
+                        combined = combined == null ? category : Combine(combined, category);
+                        if (combined == null) return null;
+                    }
+
+                    return combined;
+                }
+
+                default:
+                    return null;
+            }
+        }
+
+        // Folds a pure-number subtree to a concrete value; null if it isn't purely numeric.
+        public static double? FoldNumber(CalcNode node)
+        {
+            switch (node)
+            {
+                case NumberCalcNode number:
+                    return number.Value;
+
+                case UnaryCalcNode unary:
+                {
+                    var value = FoldNumber(unary.Operand);
+                    return value == null ? (double?) null : unary.Negative ? -value.Value : value.Value;
+                }
+
+                case BinaryCalcNode binary:
+                {
+                    var left = FoldNumber(binary.Left);
+                    var right = FoldNumber(binary.Right);
+                    if (left == null || right == null) return null;
+
+                    switch (binary.Operator)
+                    {
+                        case '+': return left.Value + right.Value;
+                        case '-': return left.Value - right.Value;
+                        case '*': return left.Value * right.Value;
+                        case '/': return right.Value != 0d ? left.Value / right.Value : (double?) null;
+                        default: return null;
+                    }
+                }
+
+                case CallCalcNode call:
+                {
+                    var values = new List<double>(call.Arguments.Count);
+                    foreach (var argument in call.Arguments)
+                    {
+                        var value = FoldNumber(argument);
+                        if (value == null) return null;
+                        values.Add(value.Value);
+                    }
+
+                    if (call.Name.Isi(FunctionNames.Min)) return values.Min();
+                    if (call.Name.Isi(FunctionNames.Max)) return values.Max();
+                    if (call.Name.Isi(FunctionNames.Clamp) && values.Count == 3)
+                    {
+                        var min = values[0];
+                        var val = values[1];
+                        var max = values[2];
+                        // clamp(min, val, max) == max(min, min(val, max)); if min > max, min wins.
+                        var upper = val < max ? val : max;
+                        return upper < min ? min : upper;
+                    }
+
+                    return null;
+                }
+
+                default:
+                    // Dimension/percentage leaves are never purely numeric.
+                    return null;
+            }
+        }
+
+        private static CalcCategory? Combine(CalcCategory? left, CalcCategory? right)
+        {
+            if (left == null || right == null) return null;
+            if (left == CalcCategory.Number && right == CalcCategory.Number) return CalcCategory.Number;
+            if (left.Value.HasFlag(CalcCategory.Number) || right.Value.HasFlag(CalcCategory.Number)) return null;
+            return left.Value | right.Value;
+        }
+    }
+}

--- a/src/ExCSS/Enumerations/FunctionNames.cs
+++ b/src/ExCSS/Enumerations/FunctionNames.cs
@@ -20,6 +20,9 @@
         public static readonly string Counter = "counter";
         public static readonly string Counters = "counters";
         public static readonly string Calc = "calc";
+        public static readonly string Min = "min";
+        public static readonly string Max = "max";
+        public static readonly string Clamp = "clamp";
         public static readonly string Toggle = "toggle";
         public static readonly string Translate = "translate";
         public static readonly string TranslateX = "translateX";

--- a/src/ExCSS/Model/Converters.cs
+++ b/src/ExCSS/Model/Converters.cs
@@ -6,10 +6,12 @@ namespace ExCSS
     internal static class Converters
     {
         public static readonly IValueConverter LineWidthConverter =
-            new StructValueConverter<Length>(ValueExtensions.ToBorderWidth);
+            new StructValueConverter<Length>(ValueExtensions.ToBorderWidth)
+                .Or(new CalcValueConverter(CalcCategory.Length));
 
         public static readonly IValueConverter LengthConverter =
-            new StructValueConverter<Length>(ValueExtensions.ToLength);
+            new StructValueConverter<Length>(ValueExtensions.ToLength)
+                .Or(new CalcValueConverter(CalcCategory.Length));
 
         public static readonly IValueConverter ResolutionConverter =
             new StructValueConverter<Resolution>(ValueExtensions.ToResolution);
@@ -44,10 +46,12 @@ namespace ExCSS
             BinaryConverter = new StructValueConverter<int>(ValueExtensions.ToBinary);
 
         public static readonly IValueConverter
-            AngleConverter = new StructValueConverter<Angle>(ValueExtensions.ToAngle);
+            AngleConverter = new StructValueConverter<Angle>(ValueExtensions.ToAngle)
+                .Or(new CalcValueConverter(CalcCategory.Angle));
 
         public static readonly IValueConverter NumberConverter =
-            new StructValueConverter<float>(ValueExtensions.ToSingle);
+            new StructValueConverter<float>(ValueExtensions.ToSingle)
+                .Or(new CalcValueConverter(CalcCategory.Number));
 
         public static readonly IValueConverter NaturalNumberConverter =
             new StructValueConverter<float>(ValueExtensions.ToNaturalSingle);
@@ -65,7 +69,8 @@ namespace ExCSS
             new StructValueConverter<Color>(ValueExtensions.ToColor);
 
         public static readonly IValueConverter LengthOrPercentConverter =
-            new StructValueConverter<Length>(ValueExtensions.ToDistance);
+            new StructValueConverter<Length>(ValueExtensions.ToDistance)
+                .Or(new CalcValueConverter(CalcCategory.LengthPercentage));
 
         public static readonly IValueConverter PercentOrFractionConverter =
             new StructValueConverter<Percent>(ValueExtensions.ToPercentOrFraction);
@@ -74,7 +79,8 @@ namespace ExCSS
             new StructValueConverter<Number>(ValueExtensions.ToPercentOrNumber);
 
         public static readonly IValueConverter AngleNumberConverter =
-            new StructValueConverter<Angle>(ValueExtensions.ToAngleNumber);
+            new StructValueConverter<Angle>(ValueExtensions.ToAngleNumber)
+                .Or(new CalcValueConverter(CalcCategory.Angle | CalcCategory.Number));
 
         public static readonly IValueConverter SideOrCornerConverter = WithAny(
             Assign(Keywords.Left, -1.0).Or(Keywords.Right, 1.0).Option(0.0),

--- a/src/ExCSS/Parser/Lexer.cs
+++ b/src/ExCSS/Parser/Lexer.cs
@@ -1038,11 +1038,27 @@ namespace ExCSS
         private Token NewFunction(string value)
         {
             var function = new FunctionToken(value, _position);
+
+            // Track paren depth so a bare parenthesized group nested in the arguments - e.g.
+            // calc((100% - 20px) / 3) - isn't mistaken for the end of the function; only the ')' matching
+            // this function's own '(' terminates it. (Also submitted standalone as the nested-parentheses
+            // lexer fix; if that merges first, this rebases cleanly.)
+            var depth = 1;
             var token = Get();
             while (token.Type != TokenType.EndOfFile)
             {
                 function.AddArgumentToken(token);
-                if (token.Type == TokenType.RoundBracketClose) break;
+
+                if (token.Type == TokenType.RoundBracketOpen)
+                {
+                    depth++;
+                }
+                else if (token.Type == TokenType.RoundBracketClose)
+                {
+                    depth--;
+                    if (depth == 0) break;
+                }
+
                 token = Get();
             }
 

--- a/src/ExCSS/ValueConverters/CalcValueConverter.cs
+++ b/src/ExCSS/ValueConverters/CalcValueConverter.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// Accepts a calc()/min()/max()/clamp() expression whose type-checked category is within
+    /// <c>allowed</c>, and preserves the authored text. Composed onto the existing length/percent/number/
+    /// angle converters via <c>.Or(...)</c> so support cascades to every property built on them.
+    /// </summary>
+    internal sealed class CalcValueConverter : IValueConverter
+    {
+        private readonly CalcCategory _allowed;
+
+        public CalcValueConverter(CalcCategory allowed)
+        {
+            _allowed = allowed;
+        }
+
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            if (value.OnlyOrDefault() is not FunctionToken function) return null;
+            if (!CalcParser.IsCalcFamily(function.Data)) return null;
+
+            var node = CalcParser.Parse(function);
+            if (node == null) return null;
+
+            var category = CalcTypeChecker.Check(node);
+            if (category == null || (category.Value & ~_allowed) != 0) return null;
+
+            return new CalcValue(value);
+        }
+
+        public IPropertyValue Construct(Property[] properties)
+        {
+            return properties.Guard<CalcValue>();
+        }
+
+        private sealed class CalcValue : IPropertyValue
+        {
+            public CalcValue(IEnumerable<Token> tokens)
+            {
+                Original = new TokenValue(tokens);
+            }
+
+            public string CssText => Original.Text;
+
+            public TokenValue Original { get; }
+
+            public TokenValue ExtractFor(string name) => Original;
+        }
+    }
+}


### PR DESCRIPTION
### Feature

`calc()`, `min()`, `max()` and `clamp()` ([CSS Values 4 §10](https://www.w3.org/TR/css-values-4/#calc-notation)) were rejected everywhere:

```css
width: calc(100% - 20px);
width: clamp(200px, 50%, 500px);
margin-top: calc(10px * 2);
transform: rotate(calc(45deg * 2));
```

### Implementation

- **`CalcParser`** — a recursive-descent parser for the `<calc-sum>`/`<calc-product>`/`<calc-value>` grammar, including nested `min`/`max`/`clamp` and parenthesized groups. Binary `+`/`-` require whitespace on both sides; `*`/`/` don't.
- **`CalcTypeChecker`** — the [§10.10 type-checking rules](https://www.w3.org/TR/css-values-4/#calc-type-checking): resolves each expression to a `CalcCategory` (number/length/percentage/angle/…) or rejects a dimensionally-inconsistent one. It folds pure-number subtrees so a constant divide-by-zero is caught here.
- **`CalcValueConverter`** — accepts a calc expression whose category fits the context, and preserves the authored text. Composed onto the length, line-width, angle, number, length-or-percent, and angle-or-number converters, so support cascades to every property built on them.

Type-checking rejects `calc(1px + 1s)`, `calc(10px * 20px)`, `calc(100% / 0)`, `calc(1px +1px)` (missing space), `calc(5)` in a length context, `clamp(1px, 2px)` (wrong arity), and empty/malformed input.

The evaluation of a calc() against layout context (`em`/`%` → pixels) is out of scope for a parser — only parsing, type-checking and serialization are provided.

### Dependency

A parenthesized group inside the arguments — `calc((100% - 20px) / 3)` — needs the nested-parentheses lexer fix (**"Fix function tokens terminating at a nested closing parenthesis"**, #190). This branch includes that one change so it's self-contained; if #190 merges first, it rebases cleanly.

### Tests

19 cases in `PropertyTests/CalcPropertyTests.cs`: calc/min/max/clamp/nesting in a length context, angle-context calc, text preservation, and eight type-check/grammar rejections.

The full suite (1263 existing tests) stays green — wiring calc into the core numeric converters disturbs nothing — and all seven target frameworks build with no new warnings.
