### PR TITLE
Support @page named selectors, selector lists, size, and the page property

### DIFF
--- a/src/ExCSS.Tests/PropertyTests/PageRuleTests.cs
+++ b/src/ExCSS.Tests/PropertyTests/PageRuleTests.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using Xunit;
+
+namespace ExCSS.Tests.PropertyTests
+{
+    public class PageRuleTests : CssConstructionFunctions
+    {
+        private static PageRule ParsePage(string source)
+        {
+            var sheet = ParseStyleSheet(source);
+            return (PageRule)sheet.Rules.First();
+        }
+
+        [Theory]
+        // CSS Paged Media 3 4.1: an @page selector is a comma-separated list of "[<name>]? [:<pseudo>]?"
+        // entries.
+        [InlineData("@page :left { margin: 1cm }", ":left")]
+        [InlineData("@page :first { margin: 1cm }", ":first")]
+        [InlineData("@page chapter { margin: 1cm }", "chapter")]
+        [InlineData("@page chapter:left { margin: 1cm }", "chapter:left")]
+        [InlineData("@page chapter1:left, chapter2:left { margin: 1cm }", "chapter1:left, chapter2:left")]
+        [InlineData("@page a, b, c { margin: 1cm }", "a, b, c")]
+        public void PageSelectorForms(string source, string expectedSelector)
+        {
+            var rule = ParsePage(source);
+
+            Assert.Equal(RuleType.Page, rule.Type);
+            Assert.Equal(expectedSelector, rule.SelectorText);
+        }
+
+        [Fact]
+        public void PageSelectorListEntriesAreExposed()
+        {
+            var rule = ParsePage("@page chapter1:left, chapter2:right { margin: 1cm }");
+            var selector = Assert.IsType<PageSelector>(rule.Selector);
+
+            Assert.Equal(2, selector.Entries.Count);
+            Assert.Equal("chapter1", selector.Entries[0].Name);
+            Assert.Equal("left", selector.Entries[0].Pseudo);
+            Assert.Equal("chapter2", selector.Entries[1].Name);
+            Assert.Equal("right", selector.Entries[1].Pseudo);
+        }
+
+        [Theory]
+        // The @page "size" descriptor (CSS Paged Media 3 6.3).
+        [InlineData("size: A4", "A4")]
+        [InlineData("size: letter", "letter")]
+        [InlineData("size: landscape", "landscape")]
+        [InlineData("size: 8.5in 11in", "8.5in 11in")]
+        [InlineData("size: 210mm", "210mm")]
+        public void PageSizeDescriptor(string declaration, string value)
+        {
+            var style = ParseDeclarations(declaration);
+
+            Assert.Equal(value, style.Size);
+        }
+
+        [Theory]
+        // The "page" property (CSS Paged Media 3 3.4).
+        [InlineData("page: chapter", "chapter")]
+        [InlineData("page: auto", "auto")]
+        public void PageProperty(string declaration, string value)
+        {
+            var style = ParseDeclarations(declaration);
+
+            Assert.Equal(value, style.PageName);
+        }
+    }
+}

--- a/src/ExCSS/Enumerations/PropertyNames.cs
+++ b/src/ExCSS/Enumerations/PropertyNames.cs
@@ -238,6 +238,9 @@
         public static readonly string UnicodeRange = "unicode-range";
         public static readonly string Src = "src";
         public static readonly string ObjectFit = "object-fit";
+        // CSS Paged Media 3: the "page" property assigns a box to a named page; "size" is an @page descriptor.
+        public static readonly string PageName = "page";
+        public static readonly string Size = "size";
         public static readonly string ObjectPosition = "object-position";
     }
 }

--- a/src/ExCSS/Factories/PropertyFactory.cs
+++ b/src/ExCSS/Factories/PropertyFactory.cs
@@ -334,6 +334,8 @@ namespace ExCSS
             AddLonghand(PropertyNames.WordWrap, () => new OverflowWrapProperty());
             AddLonghand(PropertyNames.ZIndex, () => new ZIndexProperty(), true);
             AddLonghand(PropertyNames.ObjectFit, () => new ObjectFitProperty());
+            AddLonghand(PropertyNames.PageName, () => new PageNameProperty());
+            AddLonghand(PropertyNames.Size, () => new PageSizeProperty());
             AddLonghand(PropertyNames.ObjectPosition, () => new ObjectPositionProperty(), true);
 
             _fonts.Add(PropertyNames.Src, () => new SrcProperty());

--- a/src/ExCSS/Model/StyleDeclaration.cs
+++ b/src/ExCSS/Model/StyleDeclaration.cs
@@ -1681,5 +1681,17 @@ namespace ExCSS
             get => GetPropertyValue(PropertyNames.Zoom);
             set => SetPropertyValue(PropertyNames.Zoom, value);
         }
+
+        public string Size
+        {
+            get => GetPropertyValue(PropertyNames.Size);
+            set => SetPropertyValue(PropertyNames.Size, value);
+        }
+
+        public string PageName
+        {
+            get => GetPropertyValue(PropertyNames.PageName);
+            set => SetPropertyValue(PropertyNames.PageName, value);
+        }
     }
 }

--- a/src/ExCSS/Parser/StylesheetComposer.cs
+++ b/src/ExCSS/Parser/StylesheetComposer.cs
@@ -526,21 +526,46 @@ namespace ExCSS
 
         private PageSelector CreatePageSelector(ref Token token)
         {
-            PageSelector selector;
+            // The CSS Paged Media 3 selector grammar, per comma-separated entry: an optional <ident> page
+            // name followed by an optional :<ident> pseudo-class - "@page chapter1:left, chapter2:left"
+            // (name+pseudo), "@page chapter" (name only), "@page :first" (pseudo only). Page names are
+            // case-sensitive custom-idents; pseudo-class keywords (first/left/right) are matched
+            // case-insensitively by the caller.
+            var entries = new List<PageSelectorEntry>();
 
-            if (token.Type == TokenType.Colon)
+            while (true)
             {
-                // Add the pseudo class selector
-                token = NextToken();
-                selector = token.Type == TokenType.Ident ? new PageSelector(token.Data) : new PageSelector();
+                string name = null;
+                string pseudo = null;
 
-                //Skip past the pseudo class identifier
+                if (token.Type == TokenType.Ident)
+                {
+                    name = token.Data;
+                    token = NextToken();
+                }
+
+                if (token.Type == TokenType.Colon)
+                {
+                    token = NextToken();
+                    if (token.Type == TokenType.Ident)
+                    {
+                        pseudo = token.Data;
+                        token = NextToken();
+                    }
+                }
+
+                if (name != null || pseudo != null)
+                    entries.Add(new PageSelectorEntry(name, pseudo));
+
+                ParseComments(ref token);
+
+                if (token.Type != TokenType.Comma) break;
+
                 token = NextToken();
+                ParseComments(ref token);
             }
-            else
-            {
-                selector = new PageSelector();
-            }
+
+            var selector = new PageSelector(entries);
 
             //var start = token.Position;
 

--- a/src/ExCSS/Selectors/KeyframeSelector.cs
+++ b/src/ExCSS/Selectors/KeyframeSelector.cs
@@ -28,23 +28,45 @@ namespace ExCSS
         public string Text => this.ToCss();
     }
 
+    /// <summary>
+    /// One comma-separated entry of an <c>@page</c> selector list, e.g. the two entries of
+    /// <c>@page chapter1:left, chapter2:left</c> are <c>("chapter1", "left")</c> and
+    /// <c>("chapter2", "left")</c>. Either part may be absent: <c>@page chapter</c> has a null pseudo;
+    /// <c>@page :first</c> has a null name.
+    /// </summary>
+    public readonly struct PageSelectorEntry
+    {
+        public PageSelectorEntry(string name, string pseudo)
+        {
+            Name = name;
+            Pseudo = pseudo;
+        }
+
+        public string Name { get; }
+        public string Pseudo { get; }
+    }
+
     public sealed class PageSelector : StylesheetNode, ISelector
     {
-        private readonly string _name;
+        private readonly List<PageSelectorEntry> _entries;
 
-        public PageSelector(string name)
+        public PageSelector(IEnumerable<PageSelectorEntry> entries)
         {
-            _name = name;
+            _entries = new List<PageSelectorEntry>(entries);
         }
 
-        public PageSelector() : this(string.Empty)
-        {
-        }
+        public IReadOnlyList<PageSelectorEntry> Entries => _entries;
 
         public override void ToCss(TextWriter writer, IStyleFormatter formatter)
         {
-            var pseudo = _name == string.Empty ? "" : ":";
-            writer.Write($"{pseudo}{_name}");
+            for (var i = 0; i < _entries.Count; i++)
+            {
+                if (i > 0) writer.Write(", ");
+
+                var entry = _entries[i];
+                if (entry.Name != null) writer.Write(entry.Name);
+                if (entry.Pseudo != null) writer.Write($":{entry.Pseudo}");
+            }
         }
 
         public Priority Specificity => Priority.Inline;

--- a/src/ExCSS/StyleProperties/PageNameProperty.cs
+++ b/src/ExCSS/StyleProperties/PageNameProperty.cs
@@ -1,0 +1,18 @@
+﻿namespace ExCSS
+{
+    using static Converters;
+
+    /// <summary>
+    /// The <c>page</c> property (CSS Paged Media 3 §3.4): assigns a box to a named page defined by an
+    /// <c>@page &lt;name&gt;</c> rule.
+    /// </summary>
+    internal sealed class PageNameProperty : Property
+    {
+        internal PageNameProperty()
+            : base(PropertyNames.PageName)
+        {
+        }
+
+        internal override IValueConverter Converter => IdentifierConverter.OrDefault();
+    }
+}

--- a/src/ExCSS/StyleProperties/PageSizeProperty.cs
+++ b/src/ExCSS/StyleProperties/PageSizeProperty.cs
@@ -1,0 +1,20 @@
+﻿namespace ExCSS
+{
+    using static Converters;
+
+    /// <summary>
+    /// The <c>size</c> descriptor of an <c>@page</c> rule (CSS Paged Media 3 §6.3): a page-size keyword
+    /// (<c>A4</c>, <c>letter</c>, …), an orientation (<c>portrait</c>/<c>landscape</c>), or one or two
+    /// explicit lengths.
+    /// </summary>
+    internal sealed class PageSizeProperty : Property
+    {
+        internal PageSizeProperty()
+            : base(PropertyNames.Size)
+        {
+        }
+
+        internal override IValueConverter Converter =>
+            IdentifierConverter.Or(LengthConverter).Many(1, 2).OrDefault();
+    }
+}


### PR DESCRIPTION
### Feature

CSS Paged Media 3 named page selectors, selector lists, the `size` descriptor and the `page` property:

```css
@page chapter { margin: 1cm; }
@page chapter1:left, chapter2:left { margin: 1cm; }
@page { size: A4; }
@page { size: 8.5in 11in; }
.cover { page: chapter; }
```

On `master`, `@page` accepts only a single `:pseudo` selector — a named page or a selector list is dropped — and neither `size` nor `page` is recognised.

### Implementation

- **`PageSelector`** now holds a list of **`PageSelectorEntry`** (`Name` + `Pseudo`), and `CreatePageSelector` parses the [§4.1](https://www.w3.org/TR/css-page-3/#syntax-page-selector) grammar per comma-separated entry: an optional `<ident>` page name then an optional `:<ident>` pseudo-class. `@page :left` still works.
- The **`size`** `@page` descriptor ([§6.3](https://www.w3.org/TR/css-page-3/#page-size-prop)) — a page-size/orientation keyword (`A4`, `letter`, `landscape`) or one or two lengths — and the **`page`** property ([§3.4](https://www.w3.org/TR/css-page-3/#using-named-pages)), with `StyleDeclaration.Size` / `PageName` accessors.

### Tests

14 cases in `PropertyTests/PageRuleTests.cs`: six selector forms (pseudo-only, name-only, name+pseudo, multi-entry lists), the exposed `PageSelectorEntry` list, five `size` values, and the `page` property.

The full suite (1263 existing tests) stays green — including the existing `@page :left { size:A4; … @bottom-right{…} }` test — and all seven target frameworks build with no new warnings.

`PageSelector`'s constructor changed from `PageSelector(string)` to `PageSelector(IEnumerable<PageSelectorEntry>)`. It's a public type; flagging the source-compat change, though nothing in the library or tests constructed it directly.
