### PR TITLE
Add the string-set property and string()/content() content functions

### DIFF
--- a/src/ExCSS.Tests/PropertyTests/StringSetPropertyTests.cs
+++ b/src/ExCSS.Tests/PropertyTests/StringSetPropertyTests.cs
@@ -1,0 +1,69 @@
+using Xunit;
+
+namespace ExCSS.Tests.PropertyTests
+{
+    public class StringSetPropertyTests : CssConstructionFunctions
+    {
+        [Theory]
+        // string-set: [ <custom-ident> <content-list> ]# | none (GCPM 7.3).
+        [InlineData("chapter content()", "chapter content()")]
+        [InlineData("title \"x\"", "title \"x\"")]
+        [InlineData("heading content(text)", "heading content()")]
+        [InlineData("h string(chapter)", "h string(chapter)")]
+        [InlineData("chapter counter(page)", "chapter counter(page)")]
+        [InlineData("chapter content(), section content()", "chapter content(), section content()")]
+        [InlineData("chapter \"pre \" content()", "chapter \"pre \" content()")]
+        [InlineData("none", "none")]
+        public void StringSetLegalValues(string value, string expected)
+        {
+            var property = ParseDeclaration($"string-set: {value}");
+
+            Assert.Equal("string-set", property.Name);
+            Assert.IsType<StringSetProperty>(property);
+            var concrete = (StringSetProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Equal(expected, concrete.Value);
+        }
+
+        [Theory]
+        [InlineData("string-set: chapter")]              // a name with no content-list
+        [InlineData("string-set: \"x\"")]                // a content-list with no name
+        [InlineData("string-set: chapter content(bogus)")]
+        public void StringSetIllegalValues(string snippet)
+        {
+            var property = ParseDeclaration(snippet);
+
+            Assert.IsType<StringSetProperty>(property);
+            Assert.False(property.HasValue);
+        }
+
+        [Theory]
+        // string() and content() are also valid inside the content property.
+        [InlineData("content: string(chapter)", "string(chapter)")]
+        [InlineData("content: string(chapter, first)", "string(chapter)")]
+        [InlineData("content: string(chapter, last)", "string(chapter, last)")]
+        [InlineData("content: content(before)", "content(before)")]
+        [InlineData("content: content(text)", "content()")]
+        [InlineData("content: \"Chapter \" content()", "\"Chapter \" content()")]
+        public void ContentAcceptsStringAndContentFunctions(string declaration, string expected)
+        {
+            var property = ParseDeclaration(declaration);
+
+            Assert.Equal("content", property.Name);
+            Assert.IsType<ContentProperty>(property);
+            Assert.Equal(expected, property.Value);
+        }
+
+        [Theory]
+        [InlineData("content: string()")]                 // string() needs a name
+        [InlineData("content: string(a, bogus)")]         // invalid keyword
+        [InlineData("content: content(bogus)")]           // invalid mode
+        public void ContentRejectsMalformedFunctions(string snippet)
+        {
+            var property = ParseDeclaration(snippet);
+
+            Assert.IsType<ContentProperty>(property);
+            Assert.False(property.HasValue);
+        }
+    }
+}

--- a/src/ExCSS/Enumerations/FunctionNames.cs
+++ b/src/ExCSS/Enumerations/FunctionNames.cs
@@ -19,6 +19,8 @@
         public static readonly string Image = "image";
         public static readonly string Counter = "counter";
         public static readonly string Counters = "counters";
+        public static readonly string Content = "content";
+        public static readonly string StringFn = "string";
         public static readonly string Calc = "calc";
         public static readonly string Toggle = "toggle";
         public static readonly string Translate = "translate";

--- a/src/ExCSS/Enumerations/PropertyNames.cs
+++ b/src/ExCSS/Enumerations/PropertyNames.cs
@@ -94,6 +94,7 @@
         public static readonly string ContainerName= "container-name";
         public static readonly string ContainerType = "container-type";
         public static readonly string Content = "content";
+        public static readonly string StringSet = "string-set";
         public static readonly string CounterIncrement = "counter-increment";
         public static readonly string CounterReset = "counter-reset";
         public static readonly string Cursor = "cursor";

--- a/src/ExCSS/Factories/PropertyFactory.cs
+++ b/src/ExCSS/Factories/PropertyFactory.cs
@@ -176,6 +176,7 @@ namespace ExCSS
             AddLonghand(PropertyNames.ContainerName, () => new ContainerNameProperty());
             AddLonghand(PropertyNames.ContainerType, () => new ContainerTypeProperty());
             AddLonghand(PropertyNames.Content, () => new ContentProperty());
+            AddLonghand(PropertyNames.StringSet, () => new StringSetProperty());
             AddLonghand(PropertyNames.CounterIncrement, () => new CounterIncrementProperty());
             AddLonghand(PropertyNames.CounterReset, () => new CounterResetProperty());
             AddLonghand(PropertyNames.Cursor, () => new CursorProperty());

--- a/src/ExCSS/StyleProperties/ContentProperty.cs
+++ b/src/ExCSS/StyleProperties/ContentProperty.cs
@@ -29,7 +29,9 @@ namespace ExCSS
                 UrlConverter).Or(
                 StringConverter).Or(
                 AttrConverter).Or(
-                CounterConverter).Many()).OrDefault();
+                CounterConverter).Or(
+                new ContentFunctionConverter()).Or(
+                new StringFunctionConverter()).Many()).OrDefault();
 
         private abstract class ContentMode
         {

--- a/src/ExCSS/StyleProperties/StringSetProperty.cs
+++ b/src/ExCSS/StyleProperties/StringSetProperty.cs
@@ -1,0 +1,18 @@
+﻿namespace ExCSS
+{
+    /// <summary>
+    /// The <c>string-set</c> property (GCPM §7.3): sets one or more named strings from a content list, for
+    /// later use by the <c>string()</c> function (typically in page margin boxes).
+    /// </summary>
+    internal sealed class StringSetProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = new StringSetValueConverter().OrDefault();
+
+        internal StringSetProperty()
+            : base(PropertyNames.StringSet)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/ValueConverters/ContentFunctionConverter.cs
+++ b/src/ExCSS/ValueConverters/ContentFunctionConverter.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>content()</c> function used in <c>content</c> and <c>string-set</c> (GCPM §7.5):
+    /// <c>content()</c>, <c>content(text)</c>, <c>content(before)</c>, <c>content(after)</c>,
+    /// <c>content(first-letter)</c>. Default mode is <c>text</c>.
+    /// </summary>
+    internal sealed class ContentFunctionConverter : IValueConverter
+    {
+        private static readonly string[] ValidModes = { "text", "before", "after", "first-letter" };
+
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            if (value.OnlyOrDefault() is not FunctionToken function ||
+                !function.Data.Equals(FunctionNames.Content, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            var mode = "text";
+            var arg = function.ArgumentTokens.FirstOrDefault(t =>
+                t.Type != TokenType.Whitespace && t.Type != TokenType.RoundBracketClose);
+
+            if (arg != null)
+            {
+                if (arg is not KeywordToken keyword) return null;
+
+                var name = keyword.Data.ToLowerInvariant();
+                if (!ValidModes.Contains(name)) return null;
+                mode = name;
+            }
+
+            return new ContentFunctionValue(mode, value);
+        }
+
+        public IPropertyValue Construct(Property[] properties)
+        {
+            return properties.Guard<ContentFunctionValue>();
+        }
+
+        private sealed class ContentFunctionValue : IPropertyValue
+        {
+            private readonly string _mode;
+
+            public ContentFunctionValue(string mode, IEnumerable<Token> tokens)
+            {
+                _mode = mode;
+                Original = new TokenValue(tokens);
+            }
+
+            public string CssText => _mode == "text" ? "content()" : $"content({_mode})";
+
+            public TokenValue Original { get; }
+
+            public TokenValue ExtractFor(string name) => Original;
+        }
+    }
+}

--- a/src/ExCSS/ValueConverters/StringFunctionConverter.cs
+++ b/src/ExCSS/ValueConverters/StringFunctionConverter.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>string()</c> function used in <c>content</c> and <c>string-set</c> (GCPM §7.4):
+    /// <c>string(name)</c> with an optional keyword <c>first</c>/<c>last</c>/<c>start</c>/
+    /// <c>first-except</c>. Default keyword is <c>first</c>.
+    /// </summary>
+    internal sealed class StringFunctionConverter : IValueConverter
+    {
+        private static readonly string[] ValidKeywords = { "first", "last", "start", "first-except" };
+
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            if (value.OnlyOrDefault() is not FunctionToken function ||
+                !function.Data.Equals(FunctionNames.StringFn, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            var args = function.ArgumentTokens
+                .Where(t => t.Type != TokenType.Comma && t.Type != TokenType.Whitespace &&
+                            t.Type != TokenType.RoundBracketClose)
+                .ToArray();
+
+            if (args.Length == 0 || args[0] is not KeywordToken nameToken) return null;
+
+            var keyword = "first";
+
+            if (args.Length > 1)
+            {
+                if (args[1] is not KeywordToken keywordToken) return null;
+
+                var name = keywordToken.Data.ToLowerInvariant();
+                if (!ValidKeywords.Contains(name)) return null;
+                keyword = name;
+            }
+
+            if (args.Length > 2) return null;
+
+            return new StringFunctionValue(nameToken.Data, keyword, value);
+        }
+
+        public IPropertyValue Construct(Property[] properties)
+        {
+            return properties.Guard<StringFunctionValue>();
+        }
+
+        private sealed class StringFunctionValue : IPropertyValue
+        {
+            private readonly string _name;
+            private readonly string _keyword;
+
+            public StringFunctionValue(string name, string keyword, IEnumerable<Token> tokens)
+            {
+                _name = name;
+                _keyword = keyword;
+                Original = new TokenValue(tokens);
+            }
+
+            public string CssText => _keyword == "first"
+                ? $"string({_name})"
+                : $"string({_name}, {_keyword})";
+
+            public TokenValue Original { get; }
+
+            public TokenValue ExtractFor(string name) => Original;
+        }
+    }
+}

--- a/src/ExCSS/ValueConverters/StringSetValueConverter.cs
+++ b/src/ExCSS/ValueConverters/StringSetValueConverter.cs
@@ -1,0 +1,105 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>string-set</c> property (GCPM §7.3):
+    /// <c>[ &lt;custom-ident&gt; &lt;content-list&gt; ]# | none</c>, where a content-list item is a
+    /// <c>&lt;string&gt;</c>, <c>counter()</c>/<c>counters()</c>, <c>content()</c>, <c>string()</c>, or
+    /// <c>attr()</c>.
+    /// </summary>
+    internal sealed class StringSetValueConverter : IValueConverter
+    {
+        private readonly IValueConverter _contentListItem;
+
+        public StringSetValueConverter()
+        {
+            _contentListItem = Converters.StringConverter
+                .Or(Converters.CounterConverter)
+                .Or(new ContentFunctionConverter())
+                .Or(new StringFunctionConverter())
+                .Or(Converters.AttrConverter);
+        }
+
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            if (value.OnlyOrDefault() is KeywordToken keyword && keyword.Data.Isi(Keywords.None))
+                return new StringSetValue(null, value);
+
+            var items = value.ToList(); // comma-separated groups
+            var pairs = new List<StringSetPair>();
+
+            foreach (var item in items)
+            {
+                var pair = ParsePair(item);
+                if (pair == null) return null;
+                pairs.Add(pair);
+            }
+
+            return pairs.Count == 0 ? null : new StringSetValue(pairs, value);
+        }
+
+        private StringSetPair ParsePair(List<Token> tokens)
+        {
+            if (tokens.Count < 2) return null;
+
+            if (tokens[0] is not KeywordToken nameToken || nameToken.Type != TokenType.Ident) return null;
+
+            var contentItems = tokens.Skip(1).ToItems();
+            var values = new List<IPropertyValue>();
+
+            foreach (var contentItem in contentItems)
+            {
+                var converted = _contentListItem.Convert(contentItem);
+                if (converted == null) return null;
+                values.Add(converted);
+            }
+
+            return values.Count == 0 ? null : new StringSetPair(nameToken.Data, values);
+        }
+
+        public IPropertyValue Construct(Property[] properties)
+        {
+            return properties.Guard<StringSetValue>();
+        }
+
+        private sealed class StringSetPair
+        {
+            public StringSetPair(string name, List<IPropertyValue> contentList)
+            {
+                Name = name;
+                ContentList = contentList;
+            }
+
+            public string Name { get; }
+            public List<IPropertyValue> ContentList { get; }
+        }
+
+        private sealed class StringSetValue : IPropertyValue
+        {
+            private readonly List<StringSetPair> _pairs;
+
+            public StringSetValue(List<StringSetPair> pairs, IEnumerable<Token> tokens)
+            {
+                _pairs = pairs;
+                Original = new TokenValue(tokens);
+            }
+
+            public string CssText
+            {
+                get
+                {
+                    if (_pairs == null || _pairs.Count == 0) return Keywords.None;
+
+                    return string.Join(", ", _pairs.Select(pair =>
+                        pair.Name + " " + string.Join(" ", pair.ContentList.Select(c => c.CssText))));
+                }
+            }
+
+            public TokenValue Original { get; }
+
+            public TokenValue ExtractFor(string name) => Original;
+        }
+    }
+}


### PR DESCRIPTION
### Feature

The `string-set` property and the `string()` / `content()` functions ([CSS GCPM §7](https://www.w3.org/TR/css-gcpm-3/#named-strings)):

```css
h1 { string-set: chapter content(); }
@page { @top-center { content: string(chapter); } }
p::before { content: content(before); }
```

### Implementation

- **`StringSetProperty`** with a `StringSetValueConverter` parsing `[ <custom-ident> <content-list> ]# | none`, where a content-list item is a `<string>`, `counter()`/`counters()`, `content()`, `string()`, or `attr()`.
- **`ContentFunctionConverter`** — `content()` / `content(text|before|after|first-letter)` (default `text`).
- **`StringFunctionConverter`** — `string(name)` with an optional `first`/`last`/`start`/`first-except` keyword (default `first`).

Both functions are also accepted inside the `content` property.

### Tests

24 cases in `PropertyTests/StringSetPropertyTests.cs`: `string-set` with each content-list item type, multi-pair lists, `none`, malformed values (name with no list, list with no name, bad mode); and `string()`/`content()` inside `content`, with their keyword forms and rejections.

The full suite (1263 existing tests) stays green, and all seven target frameworks build with no new warnings.
