### PR TITLE
Fix order-independent shorthand matching for list-style and columns (#185)

### DIFF
--- a/src/ExCSS.Tests/ListProperty.cs
+++ b/src/ExCSS.Tests/ListProperty.cs
@@ -213,6 +213,50 @@
         }
 
         [Fact]
+        public void CssListStyleNoneSquareOrderIndependentLegal()
+        {
+            // Regression for TylerBrinks/ExCSS#185: the "&&" operands may appear in any order, so
+            // "none square" (image before type) must parse just like "square none". Matching the
+            // converters strictly in declaration order fails here because list-style-type greedily
+            // claims "none" before list-style-image can take it.
+            var snippet = "list-style: none square ";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("list-style", property.Name);
+            Assert.False(property.IsImportant);
+            Assert.IsType<ListStyleProperty>(property);
+            var concrete = (ListStyleProperty)property;
+            Assert.False(concrete.IsInherited);
+            Assert.True(concrete.HasValue);
+            Assert.Equal("square none", concrete.Value);
+        }
+
+        [Fact]
+        public void CssListStyleSquareNoneLegal()
+        {
+            // The already-ordered form parses through the fast path and must serialize identically.
+            var snippet = "list-style: square none ";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("list-style", property.Name);
+            Assert.IsType<ListStyleProperty>(property);
+            var concrete = (ListStyleProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Equal("square none", concrete.Value);
+        }
+
+        [Fact]
+        public void CssListStyleInsideSquareOrderIndependentLegal()
+        {
+            // Position before type - the reverse of the existing "square inside" case.
+            var snippet = "list-style: inside square ";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("list-style", property.Name);
+            Assert.IsType<ListStyleProperty>(property);
+            var concrete = (ListStyleProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Equal("square inside", concrete.Value);
+        }
+
+        [Fact]
         public void CssCounterResetLegal()
         {
             var snippet = "counter-reset: chapter section 1 page;";

--- a/src/ExCSS.Tests/PropertyTests/ColumnsProperty.cs
+++ b/src/ExCSS.Tests/PropertyTests/ColumnsProperty.cs
@@ -173,6 +173,45 @@
         }
 
         [Fact]
+        public void CssColumnsWidthAutoLegal()
+        {
+            // Control: column-width value followed by an "auto" column-count parses through the fast path.
+            var snippet = "columns: 12em auto";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("columns", property.Name);
+            Assert.IsType<ColumnsProperty>(property);
+            var concrete = (ColumnsProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Equal("12em auto", concrete.Value);
+        }
+
+        [Fact]
+        public void CssColumnsAutoWidthOrderIndependentLegal()
+        {
+            // "auto" is valid for both column-count and column-width, so an in-order match lets
+            // column-width claim "auto" and strand "12em"; order-independent matching keeps it legal.
+            var snippet = "columns: auto 12em";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("columns", property.Name);
+            Assert.IsType<ColumnsProperty>(property);
+            var concrete = (ColumnsProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Equal("12em auto", concrete.Value);
+        }
+
+        [Fact]
+        public void CssColumnsAutoCountLegal()
+        {
+            var snippet = "columns: auto 2";
+            var property = ParseDeclaration(snippet);
+            Assert.Equal("columns", property.Name);
+            Assert.IsType<ColumnsProperty>(property);
+            var concrete = (ColumnsProperty)property;
+            Assert.True(concrete.HasValue);
+            Assert.Equal("auto 2", concrete.Value);
+        }
+
+        [Fact]
         public void CssColumsAutoAutoLegal()
         {
             var snippet = "columns : auto auto";

--- a/src/ExCSS/Model/Converters.cs
+++ b/src/ExCSS/Model/Converters.cs
@@ -483,6 +483,11 @@ namespace ExCSS
             return new UnorderedOptionsConverter(converters);
         }
 
+        public static IValueConverter WithAnyOrderIndependent(params IValueConverter[] converters)
+        {
+            return new OrderIndependentOptionsConverter(converters);
+        }
+
         public static IValueConverter Continuous(IValueConverter converter)
         {
             return new ContinuousValueConverter(converter);

--- a/src/ExCSS/StyleProperties/Columns/ColumnsProperty.cs
+++ b/src/ExCSS/StyleProperties/Columns/ColumnsProperty.cs
@@ -4,7 +4,10 @@
 
     internal sealed class ColumnsProperty : ShorthandProperty
     {
-        private static readonly IValueConverter StyleConverter = WithAny(
+        // columns is order-independent (CSS Multi-column 1 - "<'column-width'> || <'column-count'>"), and
+        // both longhands accept "auto", so a positional match lets column-width claim "auto" and strand the
+        // length in "columns: auto 12em". Match in any order, like list-style (TylerBrinks/ExCSS#185).
+        private static readonly IValueConverter StyleConverter = WithAnyOrderIndependent(
             AutoLengthConverter.Option().For(PropertyNames.ColumnWidth),
             OptionalIntegerConverter.Option().For(PropertyNames.ColumnCount)).OrDefault();
 

--- a/src/ExCSS/StyleProperties/List/ListStyleProperty.cs
+++ b/src/ExCSS/StyleProperties/List/ListStyleProperty.cs
@@ -4,7 +4,10 @@
 
     internal sealed class ListStyleProperty : ShorthandProperty
     {
-        private static readonly IValueConverter StyleConverter = WithAny(
+        // list-style's operands are order-independent (CSS Lists 3 - "in any order"), so a token such as
+        // "none" that both list-style-type and list-style-image accept must not be claimed positionally.
+        // See TylerBrinks/ExCSS#185 ("list-style: none square").
+        private static readonly IValueConverter StyleConverter = WithAnyOrderIndependent(
             ListStyleConverter.Option().For(PropertyNames.ListStyleType),
             ListPositionConverter.Option().For(PropertyNames.ListStylePosition),
             OptionalImageSourceConverter.Option().For(PropertyNames.ListStyleImage)).OrDefault();

--- a/src/ExCSS/ValueConverters/OrderIndependentOptionsConverter.cs
+++ b/src/ExCSS/ValueConverters/OrderIndependentOptionsConverter.cs
@@ -1,0 +1,173 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    // Like UnorderedOptionsConverter (the WithAny combinator), but matches the operands in any order rather
+    // than only in declaration order. WithAny matches greedily left-to-right, which fails whenever an
+    // earlier converter claims a token a later one also accepts - e.g. "list-style: none square", where
+    // list-style-type takes "none" before list-style-image can (TylerBrinks/ExCSS#185).
+    //
+    // Use this ONLY for shorthands whose operands are order-independent with no positional tie-break. Some
+    // "||" (any-order) shorthands still assign longhands by position and so must NOT be reordered: animation's
+    // first <time> is animation-duration and the second is animation-delay (CSS Animations 1 3), background's
+    // first <visual-box> is background-origin and the second is background-clip (CSS Backgrounds 3 2.10), and
+    // transform-origin keeps its length form axis-ordered. The declaration-order matcher (WithAny) already
+    // satisfies those positional rules, so those shorthands stay on it; list-style (CSS Lists 3) has no such
+    // rule and is the shorthand that genuinely needs order-independent matching.
+    internal sealed class OrderIndependentOptionsConverter : IValueConverter
+    {
+        // The reorder search is O(n!); every shorthand that uses this converter has only a few operands, so
+        // cap it well below the large "&&" shorthands (background/animation have 7-8) as a safety net.
+        private const int MaxReorderableConverters = 6;
+
+        private readonly IValueConverter[] _converters;
+
+        public OrderIndependentOptionsConverter(params IValueConverter[] converters)
+        {
+            _converters = converters;
+        }
+
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            // Fast path: match the operands in declaration order, identical to WithAny. This covers every
+            // already-ordered value and keeps its serialization byte-for-byte the same.
+            var list = new List<Token>(value);
+            var options = new IPropertyValue[_converters.Length];
+            var matched = true;
+
+            for (var i = 0; i < _converters.Length; i++)
+            {
+                options[i] = _converters[i].VaryAll(list);
+
+                if (options[i] == null)
+                {
+                    matched = false;
+                    break;
+                }
+            }
+
+            if (matched && list.Count == 0) return new OptionsValue(options, value);
+
+            // Fallback: search converter orderings until one consumes every token, then keep the results in
+            // canonical converter order so ExtractFor still resolves each longhand.
+            if (_converters.Length > MaxReorderableConverters) return null;
+
+            var reordered = new IPropertyValue[_converters.Length];
+            var used = new bool[_converters.Length];
+            var remaining = new List<Token>(value);
+
+            return TryReorder(remaining, used, reordered)
+                ? new OptionsValue(reordered, value)
+                : null;
+        }
+
+        // Depth-first search over converter orderings: each step lets an unused converter consume a leading
+        // run of tokens and recurses on the rest; once every token is consumed, any converter left unused is
+        // assigned its empty default (non-null only for optional operands).
+        private bool TryReorder(List<Token> remaining, bool[] used, IPropertyValue[] options)
+        {
+            if (remaining.Count == 0)
+            {
+                for (var i = 0; i < _converters.Length; i++)
+                {
+                    if (used[i]) continue;
+
+                    var empty = _converters[i].ConvertDefault();
+
+                    if (empty == null) return false;
+
+                    options[i] = empty;
+                }
+
+                return true;
+            }
+
+            for (var i = 0; i < _converters.Length; i++)
+            {
+                if (used[i]) continue;
+
+                var snapshot = new List<Token>(remaining);
+                var value = _converters[i].VaryStart(remaining);
+
+                if (value != null && remaining.Count < snapshot.Count)
+                {
+                    used[i] = true;
+                    options[i] = value;
+
+                    if (TryReorder(remaining, used, options)) return true;
+
+                    used[i] = false;
+                }
+
+                remaining.Clear();
+                remaining.AddRange(snapshot);
+            }
+
+            return false;
+        }
+
+        public IPropertyValue Construct(Property[] properties)
+        {
+            var result = properties.Guard<OptionsValue>();
+
+            if (result != null) return result;
+
+            var values = new IPropertyValue[_converters.Length];
+
+            for (var i = 0; i < _converters.Length; i++)
+            {
+                var value = _converters[i].Construct(properties);
+
+                if (value == null) return null;
+
+                values[i] = value;
+            }
+
+            result = new OptionsValue(values, Enumerable.Empty<Token>());
+
+            return result;
+        }
+
+        private sealed class OptionsValue : IPropertyValue
+        {
+            private readonly IPropertyValue[] _options;
+
+            public OptionsValue(IPropertyValue[] options, IEnumerable<Token> tokens)
+            {
+                _options = options;
+                Original = new TokenValue(tokens);
+            }
+
+            public string CssText
+            {
+                get
+                {
+                    return string.Join(" ",
+                        _options.Where(m => !string.IsNullOrEmpty(m.CssText)).Select(m => m.CssText));
+                }
+            }
+
+            public TokenValue Original { get; }
+
+            public TokenValue ExtractFor(string name)
+            {
+                var tokens = new List<Token>();
+
+                foreach (var option in _options)
+                {
+                    var extracted = option.ExtractFor(name);
+
+                    if (extracted is {Count: > 0})
+                    {
+                        if (tokens.Count > 0) tokens.Add(Token.Whitespace);
+
+                        tokens.AddRange(extracted);
+                    }
+                }
+
+                return new TokenValue(tokens);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #185.

### Bug

Some order-independent shorthands reject a value in one operand order but accept it in another. `list-style: none square` is rejected while `list-style: square none` parses; the same fault affects `columns`:

```csharp
var sheet = new StylesheetParser().Parse("a { list-style: none square; columns: auto 12em }");
var style = sheet.StyleRules.First().Style;
// master:  style.ListStyle == "" , style.Columns == ""   (both dropped)
// here:    style.ListStyle == "square none" , style.Columns == "12em auto"
```

Both are legal:

- [`list-style`](https://www.w3.org/TR/css-lists-3/#list-style-property) — `<'list-style-position'> || <'list-style-image'> || <'list-style-type'>`
- [`columns`](https://www.w3.org/TR/css-multicol-1/#columns) — `<'column-width'> || <'column-count'>`

### Cause

`WithAny` (`UnorderedOptionsConverter`) matches its converters greedily in **declaration order** (`VaryAll` per converter, left to right). That fails whenever a token is accepted by more than one operand and an earlier converter claims it:

- `list-style`: `none` is valid for both `list-style-type` and `list-style-image`. For `none square`, `list-style-type` takes `none`, leaving `square` with no taker (image doesn't accept `square`). `square none` only works because `square` can *only* be a type.
- `columns`: `auto` is valid for both `column-width` and `column-count`. For `auto 12em`, `column-width` takes `auto`, leaving `12em` with no taker (count is `<integer>`). `12em auto` only works because `12em` can *only* be the width.

### Fix

A new `OrderIndependentOptionsConverter`:

1. **Fast path** — matches in declaration order, identical to `WithAny`. Every already-ordered value parses through this and serializes byte-for-byte as before.
2. **Fallback** (only when the in-order match fails) — a depth-first search over converter orderings until one consumes every token, then maps the results back to canonical converter order so `ExtractFor` still resolves each longhand. Bounded by a small operand cap as an O(n!) safety net.

`list-style` and `columns` are pointed at it through a new `WithAnyOrderIndependent` factory. **`WithAny` itself is left untouched.**

### Why only these two

I audited every `WithAny` user:

| Shorthand(s) | Verdict |
| --- | --- |
| **`list-style`**, **`columns`** | **Fixed** — order-independent *and* a token (`none` / `auto`) is shared between operands, so greedy order mis-claims it. |
| `border` (+ `-top/right/bottom/left`), `outline`, `column-rule`, `text-decoration`, `border-image`, `border-image-slice` | No change — order-independent but operands match **disjoint** token sets (width / style / color, etc.), so order never matters. Verified: every permutation already parses. |
| `animation`, `background` | No change — also `||`, but the spec assigns some longhands **by position** (animation's 1st/2nd `<time>` → `animation-duration`/`animation-delay`, [CSS Animations 1 §3](https://www.w3.org/TR/css-animations-1/#animation); background's two `<visual-box>` → `background-origin`/`background-clip`, [CSS Backgrounds 3 §2.10](https://www.w3.org/TR/css-backgrounds-3/#background)). The declaration-order matcher already satisfies those, and reordering would break them (also an O(n!) cost on 7–8 operands). |
| `transform-origin`, `perspective-origin` | No change — rely on operand order to keep the `<length>` form axis-ordered. |

### Tests

`ListProperty.cs`: the `#185` repro (`none square` → `square none`), the already-ordered control, and the position-before-type reverse. `PropertyTests/ColumnsProperty.cs`: the `auto 12em` repro (→ `12em auto`), the `12em auto` control, and `auto 2`. Verified fail-first — with the shorthands still on plain `WithAny`, `none square` and `auto 12em` fail; with the fix they pass.

The full existing suite (1263 tests) stays green and unmodified, and all seven target frameworks build with no new warnings.
