### PR TITLE
Add CSS Grid parsing (track lists, placement, areas, subgrid, shorthands)

### DIFF
--- a/src/ExCSS.Tests/GridLineGrammarTests.cs
+++ b/src/ExCSS.Tests/GridLineGrammarTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace ExCSS.Tests
+{
+    /// <summary>Tests for the shared <see cref="GridLineGrammar"/> — the grid <c>&lt;grid-line&gt;</c> value
+    /// (<c>auto | &lt;integer&gt; | span &lt;integer&gt;</c>).</summary>
+    public class GridLineGrammarTests : CssConstructionFunctions
+    {
+        private static IReadOnlyList<Token> Tokens(string value)
+        {
+            var lexer = new Lexer(new TextSource(value));
+            var tokens = new List<Token>();
+            var token = lexer.Get();
+            while (token.Type != TokenType.EndOfFile)
+            {
+                tokens.Add(token);
+                token = lexer.Get();
+            }
+            return tokens;
+        }
+
+        private static GridLine Parse(string value) =>
+            GridLineGrammar.TryParse(Tokens(value));
+
+        [Fact]
+        public void Auto_Parses()
+        {
+            var line = Parse("auto");
+            Assert.NotNull(line);
+            Assert.True(line.IsAuto);
+        }
+
+        [Theory]
+        [InlineData("1", 1)]
+        [InlineData("3", 3)]
+        [InlineData("-1", -1)]
+        public void IntegerLine_Parses(string value, int expected)
+        {
+            var line = Parse(value);
+            Assert.NotNull(line);
+            Assert.False(line.IsAuto);
+            Assert.False(line.IsSpan);
+            Assert.Equal(expected, line.Value);
+        }
+
+        [Theory]
+        [InlineData("span 1", 1)]
+        [InlineData("span 3", 3)]
+        public void Span_Parses(string value, int expected)
+        {
+            var line = Parse(value);
+            Assert.NotNull(line);
+            Assert.True(line.IsSpan);
+            Assert.Equal(expected, line.Value);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("0")]           // line 0 is invalid
+        [InlineData("span 0")]      // span must be >= 1
+        [InlineData("span")]        // span needs a count
+        [InlineData("span auto")]
+        [InlineData("1.5")]         // not an integer
+        [InlineData("[name]")]      // named lines out of scope here
+        [InlineData("banana")]
+        public void Invalid_ReturnsNull(string value)
+        {
+            Assert.Null(Parse(value));
+        }
+    }
+}

--- a/src/ExCSS.Tests/GridLineGrammarTests.cs
+++ b/src/ExCSS.Tests/GridLineGrammarTests.cs
@@ -56,14 +56,41 @@ namespace ExCSS.Tests
         }
 
         [Theory]
+        [InlineData("sidebar")]
+        [InlineData("main-start")]
+        public void NamedLine_Parses(string value)
+        {
+            var line = Parse(value);
+            Assert.NotNull(line);
+            Assert.False(line.IsAuto);
+            Assert.False(line.IsSpan);
+            Assert.Equal(value, line.Name);
+            Assert.Equal(1, line.Value);
+        }
+
+        [Theory]
+        [InlineData("col 2", "col", 2)]
+        [InlineData("2 col", "col", 2)]
+        [InlineData("col -1", "col", -1)]
+        public void NamedNthLine_Parses(string value, string name, int nth)
+        {
+            var line = Parse(value);
+            Assert.NotNull(line);
+            Assert.Equal(name, line.Name);
+            Assert.Equal(nth, line.Value);
+        }
+
+        [Theory]
         [InlineData("")]
         [InlineData("0")]           // line 0 is invalid
         [InlineData("span 0")]      // span must be >= 1
         [InlineData("span")]        // span needs a count
         [InlineData("span auto")]
         [InlineData("1.5")]         // not an integer
-        [InlineData("[name]")]      // named lines out of scope here
-        [InlineData("banana")]
+        [InlineData("[name]")]      // bracketed line names belong in a track list, not a <grid-line>
+        [InlineData("none")]        // a CSS-wide/reserved keyword is not a custom-ident line name
+        [InlineData("initial")]
+        [InlineData("span foo")]    // span <custom-ident> is out of v1 scope
         public void Invalid_ReturnsNull(string value)
         {
             Assert.Null(Parse(value));

--- a/src/ExCSS.Tests/GridTemplateAreasGrammarTests.cs
+++ b/src/ExCSS.Tests/GridTemplateAreasGrammarTests.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace ExCSS.Tests
+{
+    /// <summary>Tests for the shared <see cref="GridTemplateAreasGrammar"/> — the
+    /// <c>grid-template-areas</c> value (a rectangular grid of named cells).</summary>
+    public class GridTemplateAreasGrammarTests : CssConstructionFunctions
+    {
+        private static IReadOnlyList<Token> Tokens(string value)
+        {
+            var lexer = new Lexer(new TextSource(value));
+            var tokens = new List<Token>();
+            var token = lexer.Get();
+            while (token.Type != TokenType.EndOfFile)
+            {
+                tokens.Add(token);
+                token = lexer.Get();
+            }
+            return tokens;
+        }
+
+        private static GridAreas Parse(string value) =>
+            GridTemplateAreasGrammar.TryParse(Tokens(value));
+
+        [Fact]
+        public void RectangularGrid_ParsesWithAreaBounds()
+        {
+            var areas = Parse("\"header header header\" \"nav main main\" \"footer footer footer\"");
+            Assert.NotNull(areas);
+            Assert.Equal(3, areas.RowCount);
+            Assert.Equal(3, areas.ColCount);
+            Assert.Equal((0, 0, 0, 2), areas.Areas["header"]);   // whole top row
+            Assert.Equal((1, 0, 1, 0), areas.Areas["nav"]);      // row 1, col 0
+            Assert.Equal((1, 1, 1, 2), areas.Areas["main"]);     // row 1, cols 1-2
+            Assert.Equal((2, 0, 2, 2), areas.Areas["footer"]);
+        }
+
+        [Fact]
+        public void DotCells_AreEmpty_AndNotAreas()
+        {
+            var areas = Parse("\"a . b\" \". . .\"");
+            Assert.NotNull(areas);
+            Assert.Equal(2, areas.RowCount);
+            Assert.Equal(3, areas.ColCount);
+            Assert.True(areas.Areas.ContainsKey("a"));
+            Assert.True(areas.Areas.ContainsKey("b"));
+            Assert.Null(areas.Cells[0, 1]);
+            Assert.Null(areas.Cells[1, 0]);
+        }
+
+        [Fact]
+        public void TripleDot_IsAlsoAnEmptyCell()
+        {
+            var areas = Parse("\"a ... b\"");
+            Assert.NotNull(areas);
+            Assert.Null(areas.Cells[0, 1]);
+        }
+
+        [Theory]
+        [InlineData("\"a a\" \"a a a\"")]        // ragged rows (2 vs 3 columns)
+        [InlineData("\"a b\" \"b a\"")]          // 'a' is not a rectangle (diagonal)
+        [InlineData("\"a a\" \"a .\"")]          // 'a' bounding box includes an empty cell → not filled
+        [InlineData("\"a b a\"")]                // 'a' occupies cols 0 and 2 with b between → not rectangular
+        [InlineData("100px")]                    // not a string list
+        [InlineData("\"\"")]                     // an empty string row
+        [InlineData("\"a.b c\"")]                // a cell mixing a name and a dot is not a valid cell token
+        [InlineData("")]
+        public void Invalid_ReturnsNull(string value)
+        {
+            Assert.Null(Parse(value));
+        }
+    }
+}

--- a/src/ExCSS.Tests/GridTemplateShorthandTests.cs
+++ b/src/ExCSS.Tests/GridTemplateShorthandTests.cs
@@ -1,0 +1,153 @@
+using System.Linq;
+using Xunit;
+
+namespace ExCSS.Tests
+{
+    /// <summary>
+    /// The <c>grid</c> / <c>grid-template</c> mega-shorthands (CSS Grid §7.4 / §7.8) parse and expand to the
+    /// grid longhands at parse time, and — like the other reconstruction-excluded shorthands — are never
+    /// re-collapsed when a declaration block is serialized.
+    /// </summary>
+    public class GridTemplateShorthandTests : CssConstructionFunctions
+    {
+        private static StyleDeclaration Style(string declaration) =>
+            (StyleDeclaration)ParseStyleSheet($"div {{ {declaration} }}").Rules.OfType<StyleRule>().Single().Style;
+
+        // grid-template
+
+        [Fact]
+        public void GridTemplate_None_ResetsAllThree()
+        {
+            var style = Style("grid-template: none;");
+            Assert.Equal("none", style.GetPropertyValue("grid-template-rows"));
+            Assert.Equal("none", style.GetPropertyValue("grid-template-columns"));
+            Assert.Equal("none", style.GetPropertyValue("grid-template-areas"));
+        }
+
+        [Fact]
+        public void GridTemplate_RowsSlashColumns_SetsBothAxesAreasNone()
+        {
+            var style = Style("grid-template: 1fr 2fr / 100px 200px;");
+            Assert.Equal("1fr 2fr", style.GetPropertyValue("grid-template-rows"));
+            Assert.Equal("100px 200px", style.GetPropertyValue("grid-template-columns"));
+            // An omitted axis is reset to its initial value (via the CSS-wide `initial` keyword).
+            Assert.Equal("initial", style.GetPropertyValue("grid-template-areas"));
+        }
+
+        [Fact]
+        public void GridTemplate_AreasForm_SynthesizesRowsAndColumns()
+        {
+            var style = Style("grid-template: \"a a\" 40px \"b b\" / 1fr 1fr;");
+            Assert.Equal("\"a a\" \"b b\"", style.GetPropertyValue("grid-template-areas"));
+            Assert.Equal("40px auto", style.GetPropertyValue("grid-template-rows"));
+            Assert.Equal("1fr 1fr", style.GetPropertyValue("grid-template-columns"));
+        }
+
+        [Fact]
+        public void GridTemplate_AreasForm_WithLineNames_PreservesThem()
+        {
+            var style = Style("grid-template: [r1] \"a\" 10px [r2] \"b\" [r3];");
+            Assert.Equal("\"a\" \"b\"", style.GetPropertyValue("grid-template-areas"));
+            Assert.Equal("[r1] 10px [r2] auto [r3]", style.GetPropertyValue("grid-template-rows"));
+            // No explicit column track list → columns reset to its initial value.
+            Assert.Equal("initial", style.GetPropertyValue("grid-template-columns"));
+        }
+
+        [Theory]
+        // `none` is a valid <grid-template-rows>/<grid-template-columns> value on either side of the slash.
+        [InlineData("grid-template: none / 1fr 1fr;", "none", "1fr 1fr")]
+        [InlineData("grid-template: 1fr 2fr / none;", "1fr 2fr", "none")]
+        public void GridTemplate_NoneOnOneAxis_IsAccepted(string declaration, string expectedRows, string expectedColumns)
+        {
+            var style = Style(declaration);
+            Assert.Equal(expectedRows, style.GetPropertyValue("grid-template-rows"));
+            Assert.Equal(expectedColumns, style.GetPropertyValue("grid-template-columns"));
+        }
+
+        // grid
+
+        [Fact]
+        public void Grid_TemplateForm_ResetsAutoProperties()
+        {
+            var style = Style("grid: \"a\" / 1fr;");
+            Assert.Equal("\"a\"", style.GetPropertyValue("grid-template-areas"));
+            Assert.Equal("auto", style.GetPropertyValue("grid-template-rows"));
+            Assert.Equal("1fr", style.GetPropertyValue("grid-template-columns"));
+            // The grid-auto-* longhands are reset to their initial values (via the CSS-wide `initial`).
+            Assert.Equal("initial", style.GetPropertyValue("grid-auto-flow"));
+            Assert.Equal("initial", style.GetPropertyValue("grid-auto-rows"));
+            Assert.Equal("initial", style.GetPropertyValue("grid-auto-columns"));
+        }
+
+        [Fact]
+        public void Grid_ColumnAutoFlowForm_SetsRowsFlowAndAutoColumns()
+        {
+            var style = Style("grid: 1fr / auto-flow 2fr;");
+            Assert.Equal("1fr", style.GetPropertyValue("grid-template-rows"));
+            Assert.Equal("column", style.GetPropertyValue("grid-auto-flow"));
+            Assert.Equal("2fr", style.GetPropertyValue("grid-auto-columns"));
+            Assert.Equal("initial", style.GetPropertyValue("grid-template-columns"));
+        }
+
+        [Fact]
+        public void Grid_RowAutoFlowForm_WithDense_SetsColumnsFlowAndAutoRows()
+        {
+            var style = Style("grid: auto-flow dense 10px / 1fr;");
+            Assert.Equal("1fr", style.GetPropertyValue("grid-template-columns"));
+            Assert.Equal("row dense", style.GetPropertyValue("grid-auto-flow"));
+            Assert.Equal("10px", style.GetPropertyValue("grid-auto-rows"));
+        }
+
+        [Fact]
+        public void Grid_NoneRows_WithColumnAutoFlow_IsAccepted()
+        {
+            // The <grid-template-rows> side of the auto-flow form also accepts `none`.
+            var style = Style("grid: none / auto-flow 1fr;");
+            Assert.Equal("none", style.GetPropertyValue("grid-template-rows"));
+            Assert.Equal("column", style.GetPropertyValue("grid-auto-flow"));
+            Assert.Equal("1fr", style.GetPropertyValue("grid-auto-columns"));
+        }
+
+        // rejection (whole declaration dropped)
+
+        [Theory]
+        [InlineData("grid-template: 10px \"a\";")]            // track-size before the first string
+        [InlineData("grid-template: \"a\" repeat(2, 1fr);")]  // repeat() is not a valid row <track-size>
+        [InlineData("grid-template: \"a\" \"b\" / repeat(2, 1fr);")] // trailing columns are an <explicit-track-list> (no repeat())
+        [InlineData("grid-template: \"a a\" \"b\";")]         // ragged area rows
+        [InlineData("grid-template: 1fr / 2fr / 3fr;")]       // two top-level slashes
+        [InlineData("grid-template: 1fr 2fr;")]               // a bare track list is not a valid grid-template
+        [InlineData("grid: auto-flow / auto-flow;")]          // auto-flow on both sides
+        [InlineData("grid: dense 10px / 1fr;")]               // dense without auto-flow
+        public void InvalidValue_IsDropped(string declaration)
+        {
+            var style = Style(declaration);
+            Assert.Equal(string.Empty, style.GetPropertyValue("grid-template-rows"));
+            Assert.Equal(string.Empty, style.GetPropertyValue("grid-template-columns"));
+        }
+
+        // serialization: never reconstructed
+
+        [Fact]
+        public void Expanded_DoesNotReconstructMegaShorthand()
+        {
+            var sheet = ParseStyleSheet("div { grid: auto-flow dense 10px / 1fr; }");
+            var css = sheet.ToCss();
+
+            Assert.DoesNotContain("grid:", css);
+            Assert.DoesNotContain("grid-template:", css);
+            Assert.Contains("grid-auto-flow", css);
+            Assert.Contains("grid-template-columns", css);
+        }
+
+        // var() is kept whole and deferred to cascade time
+
+        [Fact]
+        public void GridTemplate_WithVar_IsNotExpandedAtParseTime()
+        {
+            var style = Style("grid-template: var(--t);");
+            // The shorthand stays whole (var() can't be sliced at parse time), so the longhands are not set.
+            Assert.Equal(string.Empty, style.GetPropertyValue("grid-template-rows"));
+        }
+    }
+}

--- a/src/ExCSS.Tests/GridTrackListGrammarTests.cs
+++ b/src/ExCSS.Tests/GridTrackListGrammarTests.cs
@@ -56,10 +56,30 @@ namespace ExCSS.Tests
         [InlineData("repeat(0, 100px)")]           // repeat count must be >= 1
         [InlineData("repeat(auto-fill)")]          // repeat needs a track body
         [InlineData("-1fr")]                        // negative flex
-        [InlineData("[line] 100px")]                // named lines are out of scope here
+        [InlineData("repeat(2, [x] 1fr)")]          // named lines inside repeat() are out of v1 scope
+        [InlineData("[unclosed 100px")]             // an unclosed [ is invalid
         public void InvalidTrackLists_ReturnNull(string value)
         {
             Assert.Null(Parse(value));
+        }
+
+        [Theory]
+        [InlineData("[sidebar-start] 200px [sidebar-end] 1fr")]
+        [InlineData("[a b] 100px [c]")]
+        [InlineData("[start] repeat(3, 100px) [end]")]
+        public void NamedLines_Parse(string value)
+        {
+            Assert.NotNull(Parse(value));
+        }
+
+        [Fact]
+        public void NamedLines_RecordSortedLineNumbers()
+        {
+            // [a] 100px [b] 100px [a] — 'a' labels lines 1 and 3, 'b' labels line 2.
+            var template = Parse("[a] 100px [b] 100px [a]");
+            Assert.NotNull(template);
+            Assert.Equal(new[] { 1, 3 }, template.LineNames["a"]);
+            Assert.Equal(new[] { 2 }, template.LineNames["b"]);
         }
 
         [Fact]

--- a/src/ExCSS.Tests/GridTrackListGrammarTests.cs
+++ b/src/ExCSS.Tests/GridTrackListGrammarTests.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace ExCSS.Tests
+{
+    /// <summary>
+    /// Tests for the shared <see cref="GridTrackListGrammar"/> — the grid <c>&lt;track-list&gt;</c>
+    /// (<c>grid-template-columns</c>/<c>-rows</c>) and <c>&lt;track-size&gt;+</c> (<c>grid-auto-columns</c>/
+    /// <c>-rows</c>) value grammars.
+    /// </summary>
+    public class GridTrackListGrammarTests : CssConstructionFunctions
+    {
+        private static IReadOnlyList<Token> Tokens(string value)
+        {
+            var lexer = new Lexer(new TextSource(value));
+            var tokens = new List<Token>();
+            var token = lexer.Get();
+            while (token.Type != TokenType.EndOfFile)
+            {
+                tokens.Add(token);
+                token = lexer.Get();
+            }
+            return tokens;
+        }
+
+        private static GridTemplate Parse(string value) =>
+            GridTrackListGrammar.TryParse(Tokens(value));
+
+        [Theory]
+        [InlineData("100px")]
+        [InlineData("100px 200px")]
+        [InlineData("1fr 2fr")]
+        [InlineData("25% 75%")]
+        [InlineData("auto")]
+        [InlineData("auto 1fr auto")]
+        [InlineData("min-content max-content")]
+        [InlineData("minmax(100px, 1fr)")]
+        [InlineData("minmax(min-content, max-content)")]
+        [InlineData("fit-content(200px)")]
+        [InlineData("repeat(3, 100px)")]
+        [InlineData("repeat(2, 1fr 2fr)")]
+        [InlineData("repeat(auto-fill, minmax(200px, 1fr))")]
+        [InlineData("repeat(auto-fit, 100px)")]
+        [InlineData("100px repeat(2, 1fr) 100px")]
+        public void ValidTrackLists_Parse(string value)
+        {
+            Assert.NotNull(Parse(value));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("none")]                       // 'none' is accepted by the property, not the grammar
+        [InlineData("banana")]
+        [InlineData("minmax(1fr, 2fr)")]           // a flex min is invalid in minmax()
+        [InlineData("minmax(100px)")]              // minmax needs two args
+        [InlineData("repeat(0, 100px)")]           // repeat count must be >= 1
+        [InlineData("repeat(auto-fill)")]          // repeat needs a track body
+        [InlineData("-1fr")]                        // negative flex
+        [InlineData("[line] 100px")]                // named lines are out of scope here
+        public void InvalidTrackLists_ReturnNull(string value)
+        {
+            Assert.Null(Parse(value));
+        }
+
+        [Fact]
+        public void RepeatFixed_ExpandsInline()
+        {
+            var template = Parse("repeat(3, 100px)");
+            Assert.NotNull(template);
+            Assert.Equal(3, template.Tracks.Count);
+            Assert.All(template.Tracks, t => Assert.Equal(GridTrackKind.Length, t.Kind));
+        }
+
+        [Fact]
+        public void Fr_ParsesAsFlexFactor()
+        {
+            var template = Parse("1fr 2fr");
+            Assert.NotNull(template);
+            Assert.Equal(GridTrackKind.Flex, template.Tracks[0].Kind);
+            Assert.Equal(1.0, template.Tracks[0].Flex, 5);
+            Assert.Equal(2.0, template.Tracks[1].Flex, 5);
+        }
+
+        [Fact]
+        public void Minmax_CapturesBothBreadths()
+        {
+            var template = Parse("minmax(100px, 1fr)");
+            Assert.NotNull(template);
+            var track = Assert.Single(template.Tracks);
+            Assert.Equal(GridTrackKind.Minmax, track.Kind);
+            Assert.Equal(GridTrackKind.Length, track.Min.Kind);
+            Assert.Equal(GridTrackKind.Flex, track.Max.Kind);
+        }
+
+        [Fact]
+        public void AutoRepeat_RecordedWithKindAndInsertIndex()
+        {
+            var template = Parse("100px repeat(auto-fill, 50px) 100px");
+            Assert.NotNull(template);
+            Assert.Equal(GridAutoRepeatKind.AutoFill, template.AutoRepeat);
+            Assert.Equal(2, template.Tracks.Count);           // the two fixed 100px tracks
+            Assert.Equal(1, template.AutoRepeatInsertIndex);  // between them
+            var repeated = Assert.Single(template.AutoRepeatTracks);
+            Assert.Equal(GridTrackKind.Length, repeated.Kind);
+        }
+
+        [Fact]
+        public void TwoAutoRepeats_AreRejected()
+        {
+            Assert.Null(Parse("repeat(auto-fill, 50px) repeat(auto-fit, 50px)"));
+        }
+
+        [Theory]
+        [InlineData("100px", 1)]
+        [InlineData("100px 200px auto", 3)]
+        public void TrackSizeList_ParsesForAutoColumns(string value, int expected)
+        {
+            var list = GridTrackListGrammar.TryParseTrackSizeList(Tokens(value));
+            Assert.NotNull(list);
+            Assert.Equal(expected, list.Count);
+        }
+
+        [Theory]
+        [InlineData("repeat(2, 100px)")]  // no repeat() allowed in a track-size list
+        [InlineData("")]
+        [InlineData("banana")]
+        public void TrackSizeList_RejectsInvalid(string value)
+        {
+            Assert.Null(GridTrackListGrammar.TryParseTrackSizeList(Tokens(value)));
+        }
+    }
+}

--- a/src/ExCSS.Tests/GridTrackListGrammarTests.cs
+++ b/src/ExCSS.Tests/GridTrackListGrammarTests.cs
@@ -131,6 +131,42 @@ namespace ExCSS.Tests
         }
 
         [Theory]
+        [InlineData("subgrid")]
+        [InlineData("subgrid [a]")]
+        [InlineData("subgrid [a b] [c]")]
+        public void Subgrid_Parses(string value)
+        {
+            var template = Parse(value);
+            Assert.NotNull(template);
+            Assert.True(template.IsSubgrid);
+            Assert.False(template.IsNone);
+            Assert.Empty(template.Tracks);
+        }
+
+        [Fact]
+        public void Subgrid_RecordsLineNamesAtSequentialLines()
+        {
+            // subgrid [a] [b c] [a] — the line-name list positions 'a' at lines 1 and 3, 'b'/'c' at line 2.
+            var template = Parse("subgrid [a] [b c] [a]");
+            Assert.NotNull(template);
+            Assert.True(template.IsSubgrid);
+            Assert.Equal(new[] { 1, 3 }, template.LineNames["a"]);
+            Assert.Equal(new[] { 2 }, template.LineNames["b"]);
+            Assert.Equal(new[] { 2 }, template.LineNames["c"]);
+        }
+
+        [Theory]
+        [InlineData("subgrid 1fr")]                 // no track size may follow subgrid
+        [InlineData("1fr subgrid")]                 // subgrid must be the first token
+        [InlineData("subgrid 100px [a]")]           // a track size mixed into the line-name list
+        [InlineData("subgrid repeat(2, [a])")]      // repeat() in a subgrid line-name list is a v1 deferral
+        [InlineData("subgrid [unclosed")]           // an unclosed [ is invalid
+        public void Subgrid_InvalidForms_ReturnNull(string value)
+        {
+            Assert.Null(Parse(value));
+        }
+
+        [Theory]
         [InlineData("100px", 1)]
         [InlineData("100px 200px auto", 3)]
         public void TrackSizeList_ParsesForAutoColumns(string value, int expected)

--- a/src/ExCSS.Tests/PropertyTests/GridBoxAlignmentProperties.cs
+++ b/src/ExCSS.Tests/PropertyTests/GridBoxAlignmentProperties.cs
@@ -1,0 +1,52 @@
+using Xunit;
+
+namespace ExCSS.Tests.PropertyTests
+{
+    public class GridBoxAlignmentPropertyTests : CssConstructionFunctions
+    {
+        [Theory]
+        [InlineData("justify-items", "center")]
+        [InlineData("justify-items", "start")]
+        [InlineData("justify-items", "end")]
+        [InlineData("justify-items", "stretch")]
+        [InlineData("justify-self", "center")]
+        [InlineData("justify-self", "auto")]
+        [InlineData("place-items", "center")]
+        [InlineData("place-items", "start end")]
+        [InlineData("place-content", "center")]
+        [InlineData("place-content", "space-between center")]
+        [InlineData("place-self", "center")]
+        [InlineData("place-self", "start end")]
+        public void BoxAlignmentLegalValues(string name, string value)
+        {
+            var property = ParseDeclaration($"{name}: {value}");
+            Assert.Equal(name, property.Name);
+            Assert.True(property.HasValue);
+        }
+
+        [Fact]
+        public void PlaceItems_ExpandsToAlignAndJustifyItems()
+        {
+            var declaration = ParseDeclarations("place-items: center start");
+            Assert.Equal("center", declaration.GetPropertyValue("align-items"));
+            Assert.Equal("start", declaration.GetPropertyValue("justify-items"));
+        }
+
+        [Fact]
+        public void PlaceSelf_SingleValueAppliesToBothAxes()
+        {
+            var declaration = ParseDeclarations("place-self: center");
+            Assert.Equal("center", declaration.GetPropertyValue("align-self"));
+            Assert.Equal("center", declaration.GetPropertyValue("justify-self"));
+        }
+
+        [Theory]
+        [InlineData("justify-items", "banana")]
+        [InlineData("place-content", "center start end")]
+        public void BoxAlignmentIllegalValues(string name, string value)
+        {
+            var property = ParseDeclaration($"{name}: {value}");
+            Assert.False(property.HasValue);
+        }
+    }
+}

--- a/src/ExCSS.Tests/PropertyTests/GridNamedLinesProperties.cs
+++ b/src/ExCSS.Tests/PropertyTests/GridNamedLinesProperties.cs
@@ -1,0 +1,59 @@
+using Xunit;
+
+namespace ExCSS.Tests.PropertyTests
+{
+    public class GridNamedLinesPropertyTests : CssConstructionFunctions
+    {
+        [Theory]
+        // End-to-end: the [name] line-name groups must survive strict value parsing (ValueBuilder must
+        // accept the square-bracket tokens) and then validate through the track-list grammar.
+        [InlineData("grid-template-columns", "[sidebar-start] 200px [sidebar-end] 1fr")]
+        [InlineData("grid-template-columns", "[a b] 100px [c]")]
+        [InlineData("grid-template-rows", "[start] repeat(3, 100px) [end]")]
+        public void NamedLineTrackLists_AreAccepted(string name, string value)
+        {
+            var property = ParseDeclaration($"{name}: {value}");
+            Assert.Equal(name, property.Name);
+            Assert.True(property.HasValue);
+        }
+
+        [Theory]
+        [InlineData("grid-template-columns", "[unclosed 100px")]
+        [InlineData("grid-template-columns", "repeat(2, [x] 1fr)")]
+        public void InvalidNamedLineTrackLists_AreDropped(string name, string value)
+        {
+            var property = ParseDeclaration($"{name}: {value}");
+            Assert.False(property.HasValue);
+        }
+
+        [Theory]
+        [InlineData("grid-column-start", "sidebar")]
+        [InlineData("grid-row-end", "main-start")]
+        [InlineData("grid-column-start", "col 2")]
+        public void NamedGridLinePlacement_IsAccepted(string name, string value)
+        {
+            var property = ParseDeclaration($"{name}: {value}");
+            Assert.True(property.HasValue);
+            Assert.Equal(value, property.Value);
+        }
+
+        [Fact]
+        public void GridColumn_BareCustomIdent_CopiesToEnd()
+        {
+            // CSS Grid 8.3.1: a bare <custom-ident> propagates to the omitted end edge.
+            var declaration = ParseDeclarations("grid-column: main");
+            Assert.Equal("main", declaration.GetPropertyValue("grid-column-start"));
+            Assert.Equal("main", declaration.GetPropertyValue("grid-column-end"));
+        }
+
+        [Fact]
+        public void GridArea_BareCustomIdent_CopiesToAllFourEdges()
+        {
+            var declaration = ParseDeclarations("grid-area: main");
+            Assert.Equal("main", declaration.GetPropertyValue("grid-row-start"));
+            Assert.Equal("main", declaration.GetPropertyValue("grid-column-start"));
+            Assert.Equal("main", declaration.GetPropertyValue("grid-row-end"));
+            Assert.Equal("main", declaration.GetPropertyValue("grid-column-end"));
+        }
+    }
+}

--- a/src/ExCSS.Tests/PropertyTests/GridPlacementProperties.cs
+++ b/src/ExCSS.Tests/PropertyTests/GridPlacementProperties.cs
@@ -22,7 +22,7 @@ namespace ExCSS.Tests.PropertyTests
         [Theory]
         [InlineData("grid-column-start", "0")]
         [InlineData("grid-column-start", "span 0")]
-        [InlineData("grid-row-end", "banana")]
+        [InlineData("grid-row-end", "none")]
         [InlineData("grid-row-end", "1.5")]
         public void PlacementLonghandIllegalValues(string name, string value)
         {
@@ -64,7 +64,7 @@ namespace ExCSS.Tests.PropertyTests
         [Theory]
         [InlineData("grid-column", "1 / 2 / 3")]
         [InlineData("grid-area", "1 / 2 / 3 / 4 / 5")]
-        [InlineData("grid-column", "banana / 2")]
+        [InlineData("grid-column", "none / 2")]
         public void PlacementShorthandIllegalValues(string name, string value)
         {
             var property = ParseDeclaration($"{name}: {value}");

--- a/src/ExCSS.Tests/PropertyTests/GridPlacementProperties.cs
+++ b/src/ExCSS.Tests/PropertyTests/GridPlacementProperties.cs
@@ -1,0 +1,74 @@
+using Xunit;
+
+namespace ExCSS.Tests.PropertyTests
+{
+    public class GridPlacementPropertyTests : CssConstructionFunctions
+    {
+        [Theory]
+        [InlineData("grid-column-start", "auto", "auto")]
+        [InlineData("grid-column-start", "3", "3")]
+        [InlineData("grid-column-start", "-1", "-1")]
+        [InlineData("grid-column-end", "span 2", "span 2")]
+        [InlineData("grid-row-start", "1", "1")]
+        [InlineData("grid-row-end", "span 3", "span 3")]
+        public void PlacementLonghandLegalValues(string name, string value, string expected)
+        {
+            var property = ParseDeclaration($"{name}: {value}");
+            Assert.Equal(name, property.Name);
+            Assert.True(property.HasValue);
+            Assert.Equal(expected, property.Value);
+        }
+
+        [Theory]
+        [InlineData("grid-column-start", "0")]
+        [InlineData("grid-column-start", "span 0")]
+        [InlineData("grid-row-end", "banana")]
+        [InlineData("grid-row-end", "1.5")]
+        public void PlacementLonghandIllegalValues(string name, string value)
+        {
+            var property = ParseDeclaration($"{name}: {value}");
+            Assert.False(property.HasValue);
+        }
+
+        [Theory]
+        [InlineData("grid-column", "1 / 3")]
+        [InlineData("grid-column", "2 / span 2")]
+        [InlineData("grid-row", "1 / -1")]
+        [InlineData("grid-area", "1 / 1 / 3 / 3")]
+        [InlineData("grid-area", "2 / 2")]
+        public void PlacementShorthandLegalValues(string name, string value)
+        {
+            var property = ParseDeclaration($"{name}: {value}");
+            Assert.Equal(name, property.Name);
+            Assert.True(property.HasValue);
+        }
+
+        [Fact]
+        public void GridColumnShorthand_ExpandsToLonghands()
+        {
+            var declaration = ParseDeclarations("grid-column: 2 / span 3");
+            Assert.Equal("2", declaration.GetPropertyValue("grid-column-start"));
+            Assert.Equal("span 3", declaration.GetPropertyValue("grid-column-end"));
+        }
+
+        [Fact]
+        public void GridArea_ExpandsToFourLonghands()
+        {
+            var declaration = ParseDeclarations("grid-area: 1 / 2 / 3 / 4");
+            Assert.Equal("1", declaration.GetPropertyValue("grid-row-start"));
+            Assert.Equal("2", declaration.GetPropertyValue("grid-column-start"));
+            Assert.Equal("3", declaration.GetPropertyValue("grid-row-end"));
+            Assert.Equal("4", declaration.GetPropertyValue("grid-column-end"));
+        }
+
+        [Theory]
+        [InlineData("grid-column", "1 / 2 / 3")]
+        [InlineData("grid-area", "1 / 2 / 3 / 4 / 5")]
+        [InlineData("grid-column", "banana / 2")]
+        public void PlacementShorthandIllegalValues(string name, string value)
+        {
+            var property = ParseDeclaration($"{name}: {value}");
+            Assert.False(property.HasValue);
+        }
+    }
+}

--- a/src/ExCSS.Tests/PropertyTests/GridTemplateAreasProperty.cs
+++ b/src/ExCSS.Tests/PropertyTests/GridTemplateAreasProperty.cs
@@ -1,0 +1,32 @@
+using Xunit;
+
+namespace ExCSS.Tests.PropertyTests
+{
+    public class GridTemplateAreasPropertyTests : CssConstructionFunctions
+    {
+        [Theory]
+        [InlineData("none")]
+        [InlineData("\"a b\" \"c d\"")]
+        [InlineData("\"header header\" \"nav main\" \"footer footer\"")]
+        [InlineData("\"a . b\"")]
+        public void GridTemplateAreasLegalValues(string value)
+        {
+            var property = ParseDeclaration($"grid-template-areas: {value}");
+            Assert.Equal("grid-template-areas", property.Name);
+            Assert.IsType<GridTemplateAreasProperty>(property);
+            Assert.True(property.HasValue);
+        }
+
+        [Theory]
+        [InlineData("\"a a\" \"a a a\"")]
+        [InlineData("\"a b a\"")]
+        [InlineData("100px")]
+        [InlineData("\"\"")]
+        public void GridTemplateAreasIllegalValues(string value)
+        {
+            var property = ParseDeclaration($"grid-template-areas: {value}");
+            Assert.IsType<GridTemplateAreasProperty>(property);
+            Assert.False(property.HasValue);
+        }
+    }
+}

--- a/src/ExCSS.Tests/PropertyTests/GridTrackProperties.cs
+++ b/src/ExCSS.Tests/PropertyTests/GridTrackProperties.cs
@@ -11,6 +11,8 @@ namespace ExCSS.Tests.PropertyTests
         [InlineData("grid-template-columns", "repeat(3, 1fr)", "repeat(3, 1fr)")]
         [InlineData("grid-template-columns", "minmax(100px, 1fr)", "minmax(100px, 1fr)")]
         [InlineData("grid-template-columns", "repeat(auto-fill, minmax(200px, 1fr))", "repeat(auto-fill, minmax(200px, 1fr))")]
+        [InlineData("grid-template-columns", "subgrid", "subgrid")]
+        [InlineData("grid-template-columns", "subgrid [a] [b]", "subgrid [a] [b]")]
         [InlineData("grid-template-rows", "auto 1fr auto", "auto 1fr auto")]
         [InlineData("grid-auto-columns", "min-content", "min-content")]
         [InlineData("grid-auto-rows", "100px 200px", "100px 200px")]

--- a/src/ExCSS.Tests/PropertyTests/GridTrackProperties.cs
+++ b/src/ExCSS.Tests/PropertyTests/GridTrackProperties.cs
@@ -1,0 +1,41 @@
+using Xunit;
+
+namespace ExCSS.Tests.PropertyTests
+{
+    public class GridTrackPropertyTests : CssConstructionFunctions
+    {
+        [Theory]
+        [InlineData("grid-template-columns", "none", "none")]
+        [InlineData("grid-template-columns", "100px 200px", "100px 200px")]
+        [InlineData("grid-template-columns", "1fr 2fr", "1fr 2fr")]
+        [InlineData("grid-template-columns", "repeat(3, 1fr)", "repeat(3, 1fr)")]
+        [InlineData("grid-template-columns", "minmax(100px, 1fr)", "minmax(100px, 1fr)")]
+        [InlineData("grid-template-columns", "repeat(auto-fill, minmax(200px, 1fr))", "repeat(auto-fill, minmax(200px, 1fr))")]
+        [InlineData("grid-template-rows", "auto 1fr auto", "auto 1fr auto")]
+        [InlineData("grid-auto-columns", "min-content", "min-content")]
+        [InlineData("grid-auto-rows", "100px 200px", "100px 200px")]
+        [InlineData("grid-auto-flow", "row", "row")]
+        [InlineData("grid-auto-flow", "column dense", "column dense")]
+        [InlineData("grid-auto-flow", "dense", "dense")]
+        public void GridTrackLegalValues(string name, string value, string expected)
+        {
+            var property = ParseDeclaration($"{name}: {value}");
+            Assert.Equal(name, property.Name);
+            Assert.True(property.HasValue);
+            Assert.Equal(expected, property.Value);
+        }
+
+        [Theory]
+        [InlineData("grid-template-columns", "banana")]
+        [InlineData("grid-template-columns", "minmax(1fr, 2fr)")]
+        [InlineData("grid-template-columns", "repeat(0, 100px)")]
+        [InlineData("grid-auto-columns", "repeat(2, 100px)")]
+        [InlineData("grid-auto-flow", "row column")]
+        [InlineData("grid-auto-flow", "dense dense")]
+        public void GridTrackIllegalValues(string name, string value)
+        {
+            var property = ParseDeclaration($"{name}: {value}");
+            Assert.False(property.HasValue);
+        }
+    }
+}

--- a/src/ExCSS/Enumerations/FunctionNames.cs
+++ b/src/ExCSS/Enumerations/FunctionNames.cs
@@ -15,6 +15,9 @@
         public static readonly string Circle = "circle";
         public static readonly string Ellipse = "ellipse";
         public static readonly string Inset = "inset";
+        public static readonly string Repeat = "repeat";
+        public static readonly string Minmax = "minmax";
+        public static readonly string FitContent = "fit-content";
         public static readonly string Attr = "attr";
         public static readonly string LinearGradient = "linear-gradient";
         public static readonly string RadialGradient = "radial-gradient";

--- a/src/ExCSS/Enumerations/Keywords.cs
+++ b/src/ExCSS/Enumerations/Keywords.cs
@@ -302,6 +302,7 @@
         public static readonly string AutoFill = "auto-fill";
         public static readonly string AutoFit = "auto-fit";
         public static readonly string Dense = "dense";
+        public static readonly string Span = "span";
         public static readonly string Content = "content";
         public static readonly string Revert = "revert";
         public static readonly string RevertLayer = "revert-layer";

--- a/src/ExCSS/Enumerations/Keywords.cs
+++ b/src/ExCSS/Enumerations/Keywords.cs
@@ -301,6 +301,7 @@
         public static readonly string FitContent = "fit-content";
         public static readonly string AutoFill = "auto-fill";
         public static readonly string AutoFit = "auto-fit";
+        public static readonly string AutoFlow = "auto-flow";
         public static readonly string Subgrid = "subgrid";
         public static readonly string Dense = "dense";
         public static readonly string Span = "span";

--- a/src/ExCSS/Enumerations/Keywords.cs
+++ b/src/ExCSS/Enumerations/Keywords.cs
@@ -299,6 +299,9 @@
         public static readonly string MaxContent = "max-content";
         public static readonly string MinContent = "min-content";
         public static readonly string FitContent = "fit-content";
+        public static readonly string AutoFill = "auto-fill";
+        public static readonly string AutoFit = "auto-fit";
+        public static readonly string Dense = "dense";
         public static readonly string Content = "content";
         public static readonly string Revert = "revert";
         public static readonly string RevertLayer = "revert-layer";

--- a/src/ExCSS/Enumerations/Keywords.cs
+++ b/src/ExCSS/Enumerations/Keywords.cs
@@ -301,6 +301,7 @@
         public static readonly string FitContent = "fit-content";
         public static readonly string AutoFill = "auto-fill";
         public static readonly string AutoFit = "auto-fit";
+        public static readonly string Subgrid = "subgrid";
         public static readonly string Dense = "dense";
         public static readonly string Span = "span";
         public static readonly string Content = "content";

--- a/src/ExCSS/Enumerations/PropertyNames.cs
+++ b/src/ExCSS/Enumerations/PropertyNames.cs
@@ -144,6 +144,11 @@
         public static readonly string Hyphens = "hyphens";
         public static readonly string ImeMode = "ime-mode";
         public static readonly string JustifyContent = "justify-content";
+        public static readonly string JustifyItems = "justify-items";
+        public static readonly string JustifySelf = "justify-self";
+        public static readonly string PlaceItems = "place-items";
+        public static readonly string PlaceContent = "place-content";
+        public static readonly string PlaceSelf = "place-self";
         public static readonly string LayoutGrid = "layout-grid";
         public static readonly string LayoutGridChar = "layout-grid-char";
         public static readonly string LayoutGridType = "layout-grid-type";

--- a/src/ExCSS/Enumerations/PropertyNames.cs
+++ b/src/ExCSS/Enumerations/PropertyNames.cs
@@ -126,6 +126,11 @@
         public static readonly string FontWeight = "font-weight";
         public static readonly string Font = "font";
         public static readonly string Gap = "gap";
+        public static readonly string GridTemplateColumns = "grid-template-columns";
+        public static readonly string GridTemplateRows = "grid-template-rows";
+        public static readonly string GridAutoColumns = "grid-auto-columns";
+        public static readonly string GridAutoRows = "grid-auto-rows";
+        public static readonly string GridAutoFlow = "grid-auto-flow";
         public static readonly string GlyphOrientationHorizontal = "glyph-orientation-horizontal";
         public static readonly string GlyphOrientationVertical = "glyph-orientation-vertical";
         public static readonly string Height = "height";

--- a/src/ExCSS/Enumerations/PropertyNames.cs
+++ b/src/ExCSS/Enumerations/PropertyNames.cs
@@ -126,6 +126,8 @@
         public static readonly string FontWeight = "font-weight";
         public static readonly string Font = "font";
         public static readonly string Gap = "gap";
+        public static readonly string Grid = "grid";
+        public static readonly string GridTemplate = "grid-template";
         public static readonly string GridTemplateColumns = "grid-template-columns";
         public static readonly string GridTemplateRows = "grid-template-rows";
         public static readonly string GridTemplateAreas = "grid-template-areas";

--- a/src/ExCSS/Enumerations/PropertyNames.cs
+++ b/src/ExCSS/Enumerations/PropertyNames.cs
@@ -131,6 +131,13 @@
         public static readonly string GridAutoColumns = "grid-auto-columns";
         public static readonly string GridAutoRows = "grid-auto-rows";
         public static readonly string GridAutoFlow = "grid-auto-flow";
+        public static readonly string GridColumn = "grid-column";
+        public static readonly string GridColumnStart = "grid-column-start";
+        public static readonly string GridColumnEnd = "grid-column-end";
+        public static readonly string GridRow = "grid-row";
+        public static readonly string GridRowStart = "grid-row-start";
+        public static readonly string GridRowEnd = "grid-row-end";
+        public static readonly string GridArea = "grid-area";
         public static readonly string GlyphOrientationHorizontal = "glyph-orientation-horizontal";
         public static readonly string GlyphOrientationVertical = "glyph-orientation-vertical";
         public static readonly string Height = "height";

--- a/src/ExCSS/Enumerations/PropertyNames.cs
+++ b/src/ExCSS/Enumerations/PropertyNames.cs
@@ -128,6 +128,7 @@
         public static readonly string Gap = "gap";
         public static readonly string GridTemplateColumns = "grid-template-columns";
         public static readonly string GridTemplateRows = "grid-template-rows";
+        public static readonly string GridTemplateAreas = "grid-template-areas";
         public static readonly string GridAutoColumns = "grid-auto-columns";
         public static readonly string GridAutoRows = "grid-auto-rows";
         public static readonly string GridAutoFlow = "grid-auto-flow";

--- a/src/ExCSS/Factories/PropertyFactory.cs
+++ b/src/ExCSS/Factories/PropertyFactory.cs
@@ -167,6 +167,18 @@ namespace ExCSS
             AddLonghand(PropertyNames.GridAutoColumns, () => new GridAutoColumnsProperty());
             AddLonghand(PropertyNames.GridAutoRows, () => new GridAutoRowsProperty());
             AddLonghand(PropertyNames.GridAutoFlow, () => new GridAutoFlowProperty());
+            AddLonghand(PropertyNames.GridColumnStart, () => new GridColumnStartProperty());
+            AddLonghand(PropertyNames.GridColumnEnd, () => new GridColumnEndProperty());
+            AddLonghand(PropertyNames.GridRowStart, () => new GridRowStartProperty());
+            AddLonghand(PropertyNames.GridRowEnd, () => new GridRowEndProperty());
+
+            AddShorthand(PropertyNames.GridColumn, () => new GridColumnProperty(),
+                PropertyNames.GridColumnStart, PropertyNames.GridColumnEnd);
+            AddShorthand(PropertyNames.GridRow, () => new GridRowProperty(),
+                PropertyNames.GridRowStart, PropertyNames.GridRowEnd);
+            AddShorthand(PropertyNames.GridArea, () => new GridAreaProperty(),
+                PropertyNames.GridRowStart, PropertyNames.GridColumnStart,
+                PropertyNames.GridRowEnd, PropertyNames.GridColumnEnd);
 
             AddShorthand(PropertyNames.ColumnRule, () => new ColumnRuleProperty(),
                 PropertyNames.ColumnRuleWidth,

--- a/src/ExCSS/Factories/PropertyFactory.cs
+++ b/src/ExCSS/Factories/PropertyFactory.cs
@@ -164,6 +164,7 @@ namespace ExCSS
 
             AddLonghand(PropertyNames.GridTemplateColumns, () => new GridTemplateColumnsProperty());
             AddLonghand(PropertyNames.GridTemplateRows, () => new GridTemplateRowsProperty());
+            AddLonghand(PropertyNames.GridTemplateAreas, () => new GridTemplateAreasProperty());
             AddLonghand(PropertyNames.GridAutoColumns, () => new GridAutoColumnsProperty());
             AddLonghand(PropertyNames.GridAutoRows, () => new GridAutoRowsProperty());
             AddLonghand(PropertyNames.GridAutoFlow, () => new GridAutoFlowProperty());

--- a/src/ExCSS/Factories/PropertyFactory.cs
+++ b/src/ExCSS/Factories/PropertyFactory.cs
@@ -180,6 +180,15 @@ namespace ExCSS
                 PropertyNames.GridRowStart, PropertyNames.GridColumnStart,
                 PropertyNames.GridRowEnd, PropertyNames.GridColumnEnd);
 
+            AddLonghand(PropertyNames.JustifyItems, () => new JustifyItemsProperty());
+            AddLonghand(PropertyNames.JustifySelf, () => new JustifySelfProperty());
+            AddShorthand(PropertyNames.PlaceItems, () => new PlaceItemsProperty(),
+                PropertyNames.AlignItems, PropertyNames.JustifyItems);
+            AddShorthand(PropertyNames.PlaceContent, () => new PlaceContentProperty(),
+                PropertyNames.AlignContent, PropertyNames.JustifyContent);
+            AddShorthand(PropertyNames.PlaceSelf, () => new PlaceSelfProperty(),
+                PropertyNames.AlignSelf, PropertyNames.JustifySelf);
+
             AddShorthand(PropertyNames.ColumnRule, () => new ColumnRuleProperty(),
                 PropertyNames.ColumnRuleWidth,
                 PropertyNames.ColumnRuleStyle,

--- a/src/ExCSS/Factories/PropertyFactory.cs
+++ b/src/ExCSS/Factories/PropertyFactory.cs
@@ -18,6 +18,12 @@ namespace ExCSS
 
         private readonly Dictionary<string, ShorthandCreator> _shorthands = new(StringComparer.OrdinalIgnoreCase);
 
+        // Shorthands that parse and expand like any other, but are NOT used to reconstruct a shorthand when
+        // serializing a declaration block: the grid mega-shorthands (grid, grid-template), whose multi-slash /
+        // areas grammar isn't worth reconstructing. Excluded from GetShorthands (the serialization query) only;
+        // CreateShorthand/GetLonghands/IsShorthand still work.
+        private readonly HashSet<string> _logicalShorthands = new(StringComparer.OrdinalIgnoreCase);
+
         private PropertyFactory()
         {
             AddLonghand(PropertyNames.AlignContent, () => new AlignContentProperty());
@@ -168,6 +174,16 @@ namespace ExCSS
             AddLonghand(PropertyNames.GridAutoColumns, () => new GridAutoColumnsProperty());
             AddLonghand(PropertyNames.GridAutoRows, () => new GridAutoRowsProperty());
             AddLonghand(PropertyNames.GridAutoFlow, () => new GridAutoFlowProperty());
+
+            // The grid mega-shorthands parse/expand like any other, but are excluded from serialization
+            // reconstruction (via _logicalShorthands): reconstructing a `grid`/`grid-template` from its
+            // longhands is not worth the complexity and could change existing output.
+            AddLogicalShorthand(PropertyNames.GridTemplate, () => new GridTemplateProperty(),
+                PropertyNames.GridTemplateRows, PropertyNames.GridTemplateColumns, PropertyNames.GridTemplateAreas);
+            AddLogicalShorthand(PropertyNames.Grid, () => new GridProperty(),
+                PropertyNames.GridTemplateRows, PropertyNames.GridTemplateColumns, PropertyNames.GridTemplateAreas,
+                PropertyNames.GridAutoFlow, PropertyNames.GridAutoRows, PropertyNames.GridAutoColumns);
+
             AddLonghand(PropertyNames.GridColumnStart, () => new GridColumnStartProperty());
             AddLonghand(PropertyNames.GridColumnEnd, () => new GridColumnEndProperty());
             AddLonghand(PropertyNames.GridRowStart, () => new GridRowStartProperty());
@@ -382,6 +398,12 @@ namespace ExCSS
             _mappings.Add(name, longhands);
         }
 
+        private void AddLogicalShorthand(string name, ShorthandCreator creator, params string[] longhands)
+        {
+            AddShorthand(name, creator, longhands);
+            _logicalShorthands.Add(name);
+        }
+
         private void AddLonghand(string name, LonghandCreator creator, bool animatable = false, bool font = false)
         {
             _longhands.Add(name, creator);
@@ -460,7 +482,10 @@ namespace ExCSS
 
         public IEnumerable<string> GetShorthands(string name)
         {
-            return from mapping in _mappings where mapping.Value.Contains(name, StringComparison.OrdinalIgnoreCase) select mapping.Key;
+            return from mapping in _mappings
+                where !_logicalShorthands.Contains(mapping.Key)
+                    && mapping.Value.Contains(name, StringComparison.OrdinalIgnoreCase)
+                select mapping.Key;
         }
 
         private delegate Property LonghandCreator();

--- a/src/ExCSS/Factories/PropertyFactory.cs
+++ b/src/ExCSS/Factories/PropertyFactory.cs
@@ -162,6 +162,12 @@ namespace ExCSS
             AddLonghand(PropertyNames.ColumnGap, () => new ColumnGapProperty(), true);
             AddLonghand(PropertyNames.ColumnSpan, () => new ColumnSpanProperty());
 
+            AddLonghand(PropertyNames.GridTemplateColumns, () => new GridTemplateColumnsProperty());
+            AddLonghand(PropertyNames.GridTemplateRows, () => new GridTemplateRowsProperty());
+            AddLonghand(PropertyNames.GridAutoColumns, () => new GridAutoColumnsProperty());
+            AddLonghand(PropertyNames.GridAutoRows, () => new GridAutoRowsProperty());
+            AddLonghand(PropertyNames.GridAutoFlow, () => new GridAutoFlowProperty());
+
             AddShorthand(PropertyNames.ColumnRule, () => new ColumnRuleProperty(),
                 PropertyNames.ColumnRuleWidth,
                 PropertyNames.ColumnRuleStyle,

--- a/src/ExCSS/GridLineGrammar.cs
+++ b/src/ExCSS/GridLineGrammar.cs
@@ -23,6 +23,8 @@ namespace ExCSS
         public static readonly GridLine Auto = new() { IsAuto = true };
         public static GridLine Span(int n) => new() { IsSpan = true, Value = n };
         public static GridLine Line(int n) => new() { Value = n };
+        public static GridLine Named(string name) => new() { Name = name, Value = 1 };
+        public static GridLine NamedNth(string name, int n) => new() { Name = name, Value = n };
     }
 
     /// <summary>
@@ -50,7 +52,31 @@ namespace ExCSS
                 && toks[1] is NumberToken { IsInteger: true } spanCount && spanCount.IntegerValue >= 1)
                 return GridLine.Span(spanCount.IntegerValue);
 
+            // <custom-ident> — a named line reference.
+            if (toks.Length == 1 && IsCustomIdent(toks[0]))
+                return GridLine.Named(toks[0].Data);
+
+            // <custom-ident> <integer> / <integer> <custom-ident> — the Nth line with that name (order-independent).
+            if (toks.Length == 2)
+            {
+                if (IsCustomIdent(toks[0]) && toks[1] is NumberToken { IsInteger: true } n1 && n1.IntegerValue != 0)
+                    return GridLine.NamedNth(toks[0].Data, n1.IntegerValue);
+                if (IsCustomIdent(toks[1]) && toks[0] is NumberToken { IsInteger: true } n2 && n2.IntegerValue != 0)
+                    return GridLine.NamedNth(toks[1].Data, n2.IntegerValue);
+            }
+
             return null;
+        }
+
+        /// <summary>Whether the token is a <c>&lt;custom-ident&gt;</c> usable as a grid line name — an ident
+        /// that is not one of the reserved keywords a grid-line value or the CSS-wide keywords may take.</summary>
+        private static bool IsCustomIdent(Token token)
+        {
+            if (token.Type != TokenType.Ident) return false;
+            var d = token.Data;
+            return !d.Isi(Keywords.Auto) && !d.Isi(Keywords.Span) && !d.Isi(Keywords.None)
+                && !d.Isi(Keywords.Inherit) && !d.Isi(Keywords.Initial) && !d.Isi(Keywords.Unset)
+                && !d.Isi(Keywords.Revert) && !d.Isi(Keywords.RevertLayer) && !d.Isi("default");
         }
     }
 }

--- a/src/ExCSS/GridLineGrammar.cs
+++ b/src/ExCSS/GridLineGrammar.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// A parsed grid <c>&lt;grid-line&gt;</c> (one edge of <c>grid-column</c>/<c>grid-row</c>/<c>grid-area</c>):
+    /// <c>auto</c>, an integer line number (may be negative — counting from the end edge), or <c>span N</c>.
+    /// Named lines (<c>&lt;custom-ident&gt;</c>) are populated by the named-line grammar extension.
+    /// </summary>
+    internal sealed class GridLine
+    {
+        public bool IsAuto { get; private set; }
+        public bool IsSpan { get; private set; }
+
+        /// <summary>The line number (for a line reference), the span count (when <see cref="IsSpan"/>), or
+        /// the 1-based Nth index for a named line (defaults to 1).</summary>
+        public int Value { get; private set; } = 1;
+
+        /// <summary>The custom-ident of a named line reference, or null when this is not a named line.</summary>
+        public string Name { get; private set; }
+
+        public static readonly GridLine Auto = new() { IsAuto = true };
+        public static GridLine Span(int n) => new() { IsSpan = true, Value = n };
+        public static GridLine Line(int n) => new() { Value = n };
+    }
+
+    /// <summary>
+    /// Shared grammar for a single grid <c>&lt;grid-line&gt;</c> value. Used to validate the
+    /// <c>grid-column-start</c>/<c>-end</c>/<c>grid-row-start</c>/<c>-end</c> longhands and the placement
+    /// shorthands.
+    /// </summary>
+    internal static class GridLineGrammar
+    {
+        internal static GridLine TryParse(IReadOnlyList<Token> tokens)
+        {
+            var toks = tokens.Where(t => t.Type != TokenType.Whitespace).ToArray();
+            if (toks.Length == 0) return null;
+
+            // auto
+            if (toks.Length == 1 && toks[0].Type == TokenType.Ident && toks[0].Data.Isi(Keywords.Auto))
+                return GridLine.Auto;
+
+            // <integer>
+            if (toks.Length == 1 && toks[0] is NumberToken { IsInteger: true } number && number.IntegerValue != 0)
+                return GridLine.Line(number.IntegerValue);
+
+            // span <integer [1,∞]>
+            if (toks.Length == 2 && toks[0].Type == TokenType.Ident && toks[0].Data.Isi(Keywords.Span)
+                && toks[1] is NumberToken { IsInteger: true } spanCount && spanCount.IntegerValue >= 1)
+                return GridLine.Span(spanCount.IntegerValue);
+
+            return null;
+        }
+    }
+}

--- a/src/ExCSS/GridTemplateAreasGrammar.cs
+++ b/src/ExCSS/GridTemplateAreasGrammar.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// A parsed <c>grid-template-areas</c> value (CSS Grid §7.3): a rectangular grid of named cells. Each
+    /// named area's 0-based inclusive bounding rectangle is recorded; a <c>.</c> (or a run of only dots) is
+    /// an unnamed empty cell.
+    /// </summary>
+    internal sealed class GridAreas
+    {
+        public int RowCount { get; internal set; }
+        public int ColCount { get; internal set; }
+
+        /// <summary>The area name at each cell (<c>[row, col]</c>), or null for an empty <c>.</c> cell.</summary>
+        public string[,] Cells { get; internal set; }
+
+        /// <summary>Each named area's 0-based inclusive rectangle (rowStart, colStart, rowEnd, colEnd).</summary>
+        public IReadOnlyDictionary<string, (int R1, int C1, int R2, int C2)> Areas { get; internal set; }
+    }
+
+    /// <summary>
+    /// Shared grammar for a <c>grid-template-areas</c> value (a series of quoted strings). Returns null for
+    /// anything invalid — including the <c>none</c> keyword, which the property accepts separately.
+    /// </summary>
+    internal static class GridTemplateAreasGrammar
+    {
+        internal static GridAreas TryParse(IReadOnlyList<Token> tokens)
+        {
+            var toks = tokens.Where(t => t.Type != TokenType.Whitespace).ToArray();
+            if (toks.Length == 0) return null;
+
+            // Every token must be a string; each string is one row.
+            if (toks.Any(t => t.Type != TokenType.String)) return null;
+
+            var rows = new List<string[]>(toks.Length);
+            int colCount = -1;
+            foreach (var t in toks)
+            {
+                var cells = ((StringToken)t).Data
+                    .Split((char[])null, System.StringSplitOptions.RemoveEmptyEntries);
+                if (cells.Length == 0) return null;          // an empty string is invalid
+                if (colCount < 0) colCount = cells.Length;
+                else if (cells.Length != colCount) return null; // ragged rows are invalid
+
+                var normalized = new string[colCount];
+                for (var c = 0; c < colCount; c++)
+                {
+                    if (IsEmptyCell(cells[c])) { normalized[c] = null; continue; }
+                    // A named cell is a <custom-ident> — a mixed "a.b" is invalid, not a name.
+                    if (cells[c].IndexOf('.') >= 0) return null;
+                    normalized[c] = cells[c];
+                }
+                rows.Add(normalized);
+            }
+
+            var rowCount = rows.Count;
+            var grid = new string[rowCount, colCount];
+            var bounds = new Dictionary<string, (int R1, int C1, int R2, int C2)>();
+
+            for (var r = 0; r < rowCount; r++)
+                for (var c = 0; c < colCount; c++)
+                {
+                    var name = rows[r][c];
+                    grid[r, c] = name;
+                    if (name is null) continue;
+                    if (bounds.TryGetValue(name, out var b))
+                        bounds[name] = (System.Math.Min(b.R1, r), System.Math.Min(b.C1, c),
+                                        System.Math.Max(b.R2, r), System.Math.Max(b.C2, c));
+                    else
+                        bounds[name] = (r, c, r, c);
+                }
+
+            // Each named area must be a single filled rectangle: every cell in its bounding box carries the
+            // name (which also guarantees no cell with the name lies outside the box).
+            foreach (var pair in bounds)
+            {
+                var name = pair.Key;
+                var b = pair.Value;
+                for (var r = b.R1; r <= b.R2; r++)
+                    for (var c = b.C1; c <= b.C2; c++)
+                        if (grid[r, c] != name) return null;
+            }
+
+            return new GridAreas { RowCount = rowCount, ColCount = colCount, Cells = grid, Areas = bounds };
+        }
+
+        /// <summary>A cell of only U+002E FULL STOP characters (<c>.</c>, <c>...</c>) is an empty cell.</summary>
+        private static bool IsEmptyCell(string cell) => cell.All(ch => ch == '.');
+    }
+}

--- a/src/ExCSS/GridTrackListGrammar.cs
+++ b/src/ExCSS/GridTrackListGrammar.cs
@@ -68,7 +68,12 @@ namespace ExCSS
         public IReadOnlyDictionary<string, IReadOnlyList<int>> LineNames { get; internal set; }
             = new Dictionary<string, IReadOnlyList<int>>();
 
-        public bool IsNone => Tracks.Count == 0 && AutoRepeat == GridAutoRepeatKind.None;
+        /// <summary>The <c>subgrid</c> keyword (CSS Grid Layout Module Level 2 §9): this axis adopts the parent
+        /// grid's tracks instead of defining its own. A subgrid template carries no <see cref="Tracks"/> — only
+        /// any explicit <c>[name]</c> line names declared after the keyword (in <see cref="LineNames"/>).</summary>
+        public bool IsSubgrid { get; internal set; }
+
+        public bool IsNone => !IsSubgrid && Tracks.Count == 0 && AutoRepeat == GridAutoRepeatKind.None;
     }
 
     /// <summary>
@@ -89,6 +94,13 @@ namespace ExCSS
         {
             var toks = tokens.Where(t => t.Type != TokenType.Whitespace).ToArray();
             if (toks.Length == 0) return null;
+
+            // subgrid (CSS Grid Level 2 §9): the axis adopts the parent grid's tracks. The keyword may be
+            // followed by an optional <line-name-list> ([name] groups only; repeat() of line names is a v1
+            // deferral, mirroring the "named lines inside repeat()" restriction below). No <track-size> is
+            // allowed after subgrid.
+            if (toks[0].Type == TokenType.Ident && toks[0].Data.Isi(Keywords.Subgrid))
+                return TryParseSubgrid(toks);
 
             var fixedTracks = new List<GridTrackSize>();
             var autoRepeat = GridAutoRepeatKind.None;
@@ -154,6 +166,46 @@ namespace ExCSS
                 AutoRepeat = autoRepeat,
                 AutoRepeatTracks = autoRepeatTracks,
                 AutoRepeatInsertIndex = autoRepeatIndex < 0 ? 0 : autoRepeatIndex,
+                LineNames = lineNames.ToDictionary(
+                    kv => kv.Key,
+                    kv => (IReadOnlyList<int>)kv.Value.ToList())
+            };
+        }
+
+        /// <summary>
+        /// Parses a <c>subgrid [ &lt;line-name-list&gt; ]?</c> value (the leading <c>subgrid</c> ident already
+        /// matched by the caller). The optional line-name list is a run of <c>[name …]</c> bracket groups, one
+        /// group per grid line (line 1 is before the first adopted track); each group's names are recorded at
+        /// that 1-based line index. Anything else after <c>subgrid</c> (a track size, an unclosed/ill-formed
+        /// bracket, a non-ident inside <c>[ ]</c>) is invalid.
+        /// </summary>
+        private static GridTemplate TryParseSubgrid(Token[] toks)
+        {
+            var lineNames = new Dictionary<string, SortedSet<int>>();
+            var lineIndex = 1;
+            var i = 1; // skip the subgrid ident
+
+            while (i < toks.Length)
+            {
+                if (toks[i].Type != TokenType.SquareBracketOpen) return null; // only [name] groups may follow
+                i++;
+                while (i < toks.Length && toks[i].Type != TokenType.SquareBracketClose)
+                {
+                    if (toks[i].Type != TokenType.Ident) return null;
+                    var name = toks[i].Data;
+                    if (!lineNames.TryGetValue(name, out var set))
+                        lineNames[name] = set = new SortedSet<int>();
+                    set.Add(lineIndex);
+                    i++;
+                }
+                if (i >= toks.Length) return null; // unclosed [
+                i++; // consume ]
+                lineIndex++;
+            }
+
+            return new GridTemplate
+            {
+                IsSubgrid = true,
                 LineNames = lineNames.ToDictionary(
                     kv => kv.Key,
                     kv => (IReadOnlyList<int>)kv.Value.ToList())

--- a/src/ExCSS/GridTrackListGrammar.cs
+++ b/src/ExCSS/GridTrackListGrammar.cs
@@ -63,6 +63,11 @@ namespace ExCSS
         /// <summary>The index into <see cref="Tracks"/> at which the auto-repeat section is inserted.</summary>
         public int AutoRepeatInsertIndex { get; internal set; }
 
+        /// <summary>Named lines declared with <c>[name]</c> in the top-level track list: name → the sorted,
+        /// deduped 1-based line numbers it labels (line 1 is before the first track). Empty when none.</summary>
+        public IReadOnlyDictionary<string, IReadOnlyList<int>> LineNames { get; internal set; }
+            = new Dictionary<string, IReadOnlyList<int>>();
+
         public bool IsNone => Tracks.Count == 0 && AutoRepeat == GridAutoRepeatKind.None;
     }
 
@@ -89,10 +94,31 @@ namespace ExCSS
             var autoRepeat = GridAutoRepeatKind.None;
             List<GridTrackSize> autoRepeatTracks = null;
             var autoRepeatIndex = -1;
+            var lineNames = new Dictionary<string, SortedSet<int>>();
 
             var i = 0;
             while (i < toks.Length)
             {
+                // [name …] — one or more named lines at the current line position (1-based; line 1 is before
+                // the first track). Whitespace is already stripped, so the bracket group is contiguous.
+                if (toks[i].Type == TokenType.SquareBracketOpen)
+                {
+                    var lineIndex = fixedTracks.Count + 1;
+                    i++;
+                    while (i < toks.Length && toks[i].Type != TokenType.SquareBracketClose)
+                    {
+                        if (toks[i].Type != TokenType.Ident) return null; // only idents inside [ ]
+                        var name = toks[i].Data;
+                        if (!lineNames.TryGetValue(name, out var set))
+                            lineNames[name] = set = new SortedSet<int>();
+                        set.Add(lineIndex);
+                        i++;
+                    }
+                    if (i >= toks.Length) return null; // unclosed [
+                    i++; // consume ]
+                    continue;
+                }
+
                 if (toks[i] is FunctionToken fn && fn.Data.Isi(FunctionNames.Repeat))
                 {
                     if (!TryParseRepeat(fn, out var repeatKind, out var repeatTracks)) return null;
@@ -127,7 +153,10 @@ namespace ExCSS
                 Tracks = fixedTracks,
                 AutoRepeat = autoRepeat,
                 AutoRepeatTracks = autoRepeatTracks,
-                AutoRepeatInsertIndex = autoRepeatIndex < 0 ? 0 : autoRepeatIndex
+                AutoRepeatInsertIndex = autoRepeatIndex < 0 ? 0 : autoRepeatIndex,
+                LineNames = lineNames.ToDictionary(
+                    kv => kv.Key,
+                    kv => (IReadOnlyList<int>)kv.Value.ToList())
             };
         }
 

--- a/src/ExCSS/GridTrackListGrammar.cs
+++ b/src/ExCSS/GridTrackListGrammar.cs
@@ -1,0 +1,307 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>The kind of a single grid <c>&lt;track-size&gt;</c>/<c>&lt;track-breadth&gt;</c>
+    /// (CSS Grid Layout Module Level 1/2 §7.2).</summary>
+    internal enum GridTrackKind
+    {
+        Length,       // a <length> (raw component string in Value)
+        Percent,      // a <percentage> (raw component string in Value)
+        Flex,         // a <flex> / fr value (Flex holds the fr number)
+        Auto,
+        MinContent,
+        MaxContent,
+        FitContent,   // fit-content(<length-percentage>) — the argument is in Value
+        Minmax        // minmax(Min, Max)
+    }
+
+    /// <summary>Which flavour of layout-time <c>repeat()</c> a template carries (CSS Grid §7.2.3.2).</summary>
+    internal enum GridAutoRepeatKind { None, AutoFill, AutoFit }
+
+    /// <summary>
+    /// A single grid <c>&lt;track-size&gt;</c>. Fixed/percentage/fit-content values keep their authored
+    /// component string (<see cref="Value"/>); <c>fr</c> keeps its numeric factor (<see cref="Flex"/>);
+    /// <c>minmax()</c> keeps its two sub-breadths.
+    /// </summary>
+    internal sealed class GridTrackSize
+    {
+        public GridTrackKind Kind { get; private set; }
+        public string Value { get; private set; }
+        public double Flex { get; private set; }
+        public GridTrackSize Min { get; private set; }
+        public GridTrackSize Max { get; private set; }
+
+        public static GridTrackSize Length(string v) => new() { Kind = GridTrackKind.Length, Value = v };
+        public static GridTrackSize Percent(string v) => new() { Kind = GridTrackKind.Percent, Value = v };
+        public static GridTrackSize FlexFactor(double fr) => new() { Kind = GridTrackKind.Flex, Flex = fr };
+        public static readonly GridTrackSize Auto = new() { Kind = GridTrackKind.Auto };
+        public static readonly GridTrackSize MinContent = new() { Kind = GridTrackKind.MinContent };
+        public static readonly GridTrackSize MaxContent = new() { Kind = GridTrackKind.MaxContent };
+        public static GridTrackSize FitContentTo(string v) => new() { Kind = GridTrackKind.FitContent, Value = v };
+        public static GridTrackSize Minmax(GridTrackSize min, GridTrackSize max) =>
+            new() { Kind = GridTrackKind.Minmax, Min = min, Max = max };
+    }
+
+    /// <summary>
+    /// A parsed <c>grid-template-columns</c>/<c>grid-template-rows</c> value: the fixed (fully
+    /// <c>repeat(N,…)</c>-expanded) tracks, plus at most one layout-time <c>repeat(auto-fill|auto-fit,…)</c>
+    /// section recorded as an insertion point since its count is resolved during layout.
+    /// </summary>
+    internal sealed class GridTemplate
+    {
+        /// <summary>The fixed tracks (with the auto-repeat section, if any, NOT included here — it is
+        /// spliced in at <see cref="AutoRepeatInsertIndex"/> at layout time).</summary>
+        public IReadOnlyList<GridTrackSize> Tracks { get; internal set; } = new List<GridTrackSize>();
+
+        public GridAutoRepeatKind AutoRepeat { get; internal set; } = GridAutoRepeatKind.None;
+
+        /// <summary>The repeated track template for an <c>auto-fill</c>/<c>auto-fit</c> section.</summary>
+        public IReadOnlyList<GridTrackSize> AutoRepeatTracks { get; internal set; }
+
+        /// <summary>The index into <see cref="Tracks"/> at which the auto-repeat section is inserted.</summary>
+        public int AutoRepeatInsertIndex { get; internal set; }
+
+        public bool IsNone => Tracks.Count == 0 && AutoRepeat == GridAutoRepeatKind.None;
+    }
+
+    /// <summary>
+    /// Shared grammar for the grid <c>&lt;track-list&gt;</c> (<c>grid-template-columns</c>/
+    /// <c>grid-template-rows</c>) and <c>&lt;track-size&gt;+</c> (<c>grid-auto-columns</c>/
+    /// <c>grid-auto-rows</c>). Mirrors the ExCSS grammar-helper precedent so the grammar is defined once.
+    /// Named lines (<c>[name]</c>) and <c>grid-template-areas</c> are out of the fixed track-list scope
+    /// here and rejected.
+    /// </summary>
+    internal static class GridTrackListGrammar
+    {
+        /// <summary>
+        /// Parses a <c>&lt;track-list&gt;</c> (the <c>grid-template-columns</c>/<c>-rows</c> value). Returns
+        /// null when the value is not a valid track list — <b>including the literal <c>none</c></b>, which
+        /// the property accepts separately.
+        /// </summary>
+        internal static GridTemplate TryParse(IReadOnlyList<Token> tokens)
+        {
+            var toks = tokens.Where(t => t.Type != TokenType.Whitespace).ToArray();
+            if (toks.Length == 0) return null;
+
+            var fixedTracks = new List<GridTrackSize>();
+            var autoRepeat = GridAutoRepeatKind.None;
+            List<GridTrackSize> autoRepeatTracks = null;
+            var autoRepeatIndex = -1;
+
+            var i = 0;
+            while (i < toks.Length)
+            {
+                if (toks[i] is FunctionToken fn && fn.Data.Isi(FunctionNames.Repeat))
+                {
+                    if (!TryParseRepeat(fn, out var repeatKind, out var repeatTracks)) return null;
+
+                    if (repeatKind == GridAutoRepeatKind.None)
+                    {
+                        // repeat(N, …) — expand inline.
+                        fixedTracks.AddRange(repeatTracks);
+                    }
+                    else
+                    {
+                        // repeat(auto-fill|auto-fit, …) — at most one per track list.
+                        if (autoRepeat != GridAutoRepeatKind.None) return null;
+                        autoRepeat = repeatKind;
+                        autoRepeatTracks = repeatTracks;
+                        autoRepeatIndex = fixedTracks.Count;
+                    }
+
+                    i++;
+                    continue;
+                }
+
+                if (!TryParseTrackSize(toks[i], out var track)) return null;
+                fixedTracks.Add(track);
+                i++;
+            }
+
+            if (fixedTracks.Count == 0 && autoRepeat == GridAutoRepeatKind.None) return null;
+
+            return new GridTemplate
+            {
+                Tracks = fixedTracks,
+                AutoRepeat = autoRepeat,
+                AutoRepeatTracks = autoRepeatTracks,
+                AutoRepeatInsertIndex = autoRepeatIndex < 0 ? 0 : autoRepeatIndex
+            };
+        }
+
+        /// <summary>
+        /// Parses a <c>&lt;track-size&gt;+</c> list (<c>grid-auto-columns</c>/<c>grid-auto-rows</c>) — one or
+        /// more track sizes, no <c>repeat()</c>. Returns null on any invalid token.
+        /// </summary>
+        internal static IReadOnlyList<GridTrackSize> TryParseTrackSizeList(IReadOnlyList<Token> tokens)
+        {
+            var toks = tokens.Where(t => t.Type != TokenType.Whitespace).ToArray();
+            if (toks.Length == 0) return null;
+
+            var result = new List<GridTrackSize>();
+            foreach (var token in toks)
+            {
+                if (!TryParseTrackSize(token, out var track)) return null;
+                result.Add(track);
+            }
+
+            return result;
+        }
+
+        private static bool TryParseRepeat(FunctionToken fn, out GridAutoRepeatKind kind, out List<GridTrackSize> tracks)
+        {
+            kind = GridAutoRepeatKind.None;
+            tracks = null;
+
+            var args = fn.ArgumentTokens.Where(t => t.Type != TokenType.Whitespace).ToArray();
+            var groups = SplitByComma(args);
+            if (groups.Count < 2) return false;
+
+            // First group is the repetition count: an integer, or auto-fill / auto-fit.
+            var first = groups[0];
+            if (first.Count != 1) return false;
+
+            var countTokens = 0;
+            if (IsIdent(first[0], Keywords.AutoFill)) kind = GridAutoRepeatKind.AutoFill;
+            else if (IsIdent(first[0], Keywords.AutoFit)) kind = GridAutoRepeatKind.AutoFit;
+            else if (first[0] is NumberToken { IsInteger: true } n && n.IntegerValue >= 1) countTokens = n.IntegerValue;
+            else return false;
+
+            // Remaining groups are the repeated <track-size>s. (A repeat body may not itself contain a
+            // repeat(), which SplitByComma naturally enforces since a nested function is one token.)
+            var body = new List<GridTrackSize>();
+            for (var gi = 1; gi < groups.Count; gi++)
+            {
+                foreach (var token in groups[gi])
+                {
+                    if (!TryParseTrackSize(token, out var track)) return false;
+                    body.Add(track);
+                }
+            }
+
+            if (body.Count == 0) return false;
+
+            if (kind != GridAutoRepeatKind.None)
+            {
+                tracks = body;
+                return true;
+            }
+
+            // repeat(N, body) — expand N copies now.
+            tracks = new List<GridTrackSize>(body.Count * countTokens);
+            for (var r = 0; r < countTokens; r++)
+                tracks.AddRange(body);
+            return true;
+        }
+
+        private static bool TryParseTrackSize(Token token, out GridTrackSize track)
+        {
+            track = null;
+
+            // minmax(<inflexible-breadth>, <track-breadth>) and fit-content(<length-percentage>).
+            if (token is FunctionToken fn)
+            {
+                if (fn.Data.Isi(FunctionNames.Minmax)) return TryParseMinmax(fn, out track);
+                if (fn.Data.Isi(FunctionNames.FitContent)) return TryParseFitContent(fn, out track);
+                return false;
+            }
+
+            if (TryParseBreadth(token, out track)) return true;
+            return false;
+        }
+
+        private static bool TryParseBreadth(Token token, out GridTrackSize track)
+        {
+            track = null;
+
+            if (token.Type == TokenType.Ident)
+            {
+                if (token.Data.Isi(Keywords.Auto)) { track = GridTrackSize.Auto; return true; }
+                if (token.Data.Isi(Keywords.MinContent)) { track = GridTrackSize.MinContent; return true; }
+                if (token.Data.Isi(Keywords.MaxContent)) { track = GridTrackSize.MaxContent; return true; }
+                return false;
+            }
+
+            if (token.Type == TokenType.Percentage) { track = GridTrackSize.Percent(token.ToValue()); return true; }
+
+            if (token is UnitToken unit && token.Type == TokenType.Dimension)
+            {
+                if (unit.Unit.Isi("fr"))
+                {
+                    if (unit.Value < 0) return false;
+                    track = GridTrackSize.FlexFactor(unit.Value);
+                    return true;
+                }
+
+                // Any other dimension is a <length> — the raw string is preserved.
+                track = GridTrackSize.Length(token.ToValue());
+                return true;
+            }
+
+            // Unitless zero is a valid length.
+            if (token is NumberToken { Value: 0f }) { track = GridTrackSize.Length("0"); return true; }
+
+            return false;
+        }
+
+        private static bool TryParseMinmax(FunctionToken fn, out GridTrackSize track)
+        {
+            track = null;
+            var groups = SplitByComma(fn.ArgumentTokens.Where(t => t.Type != TokenType.Whitespace).ToArray());
+            if (groups.Count != 2 || groups[0].Count != 1 || groups[1].Count != 1) return false;
+
+            if (!TryParseBreadth(groups[0][0], out var min)) return false;
+            if (!TryParseBreadth(groups[1][0], out var max)) return false;
+
+            // The min of a minmax() is an <inflexible-breadth> — a flex value is invalid there.
+            if (min.Kind == GridTrackKind.Flex) return false;
+
+            track = GridTrackSize.Minmax(min, max);
+            return true;
+        }
+
+        private static bool TryParseFitContent(FunctionToken fn, out GridTrackSize track)
+        {
+            track = null;
+            var args = fn.ArgumentTokens.Where(t => t.Type != TokenType.Whitespace).ToArray();
+            if (args.Length != 1) return false;
+
+            // fit-content(<length-percentage>).
+            var t = args[0];
+            if (t.Type is TokenType.Percentage) { track = GridTrackSize.FitContentTo(t.ToValue()); return true; }
+            if (t is UnitToken && t.Type == TokenType.Dimension && !((UnitToken)t).Unit.Isi("fr"))
+            {
+                track = GridTrackSize.FitContentTo(t.ToValue());
+                return true;
+            }
+            if (t is NumberToken { Value: 0f }) { track = GridTrackSize.FitContentTo("0"); return true; }
+
+            return false;
+        }
+
+        private static bool IsIdent(Token token, string keyword) =>
+            token.Type == TokenType.Ident && token.Data.Isi(keyword);
+
+        private static List<List<Token>> SplitByComma(IReadOnlyList<Token> tokens)
+        {
+            var groups = new List<List<Token>>();
+            var current = new List<Token>();
+            foreach (var token in tokens)
+            {
+                if (token.Type == TokenType.Comma)
+                {
+                    groups.Add(current);
+                    current = new List<Token>();
+                }
+                else
+                {
+                    current.Add(token);
+                }
+            }
+            groups.Add(current);
+            return groups;
+        }
+    }
+}

--- a/src/ExCSS/Model/Converters.cs
+++ b/src/ExCSS/Model/Converters.cs
@@ -437,6 +437,20 @@ namespace ExCSS
             IntegerConverter.Required(),
             IntegerConverter.StartsWithDelimiter().Required());
 
+        // A single grid <grid-line> (auto | <integer> | span <integer>), validated by GridLineGrammar.
+        public static readonly IValueConverter GridLineConverter = new GridLineValueConverter();
+
+        // grid-column / grid-row / grid-area: slash-separated <grid-line> components with the CSS Grid
+        // §8.3.1 omitted-value copy rule (a bare <custom-ident> propagates to the paired/all edges) — the
+        // generic WithOrder(...).Option() DSL resets omitted slots to auto, which is wrong for named areas.
+        public static readonly IValueConverter GridColumnConverter =
+            new GridColumnRowShorthandValueConverter(PropertyNames.GridColumnStart, PropertyNames.GridColumnEnd);
+
+        public static readonly IValueConverter GridRowConverter =
+            new GridColumnRowShorthandValueConverter(PropertyNames.GridRowStart, PropertyNames.GridRowEnd);
+
+        public static readonly IValueConverter GridAreaConverter = new GridAreaShorthandValueConverter();
+
         public static readonly IValueConverter ShadowConverter = WithAny(
             Assign(Keywords.Inset, true).Option(false),
             LengthConverter.Many(2, 4).Required(),

--- a/src/ExCSS/Model/Converters.cs
+++ b/src/ExCSS/Model/Converters.cs
@@ -464,6 +464,10 @@ namespace ExCSS
 
         public static readonly IValueConverter GridAreaConverter = new GridAreaShorthandValueConverter();
 
+        public static readonly IValueConverter GridTemplateConverter = new GridTemplateShorthandValueConverter();
+
+        public static readonly IValueConverter GridConverter = new GridShorthandValueConverter();
+
         public static readonly IValueConverter ShadowConverter = WithAny(
             Assign(Keywords.Inset, true).Option(false),
             LengthConverter.Many(2, 4).Required(),

--- a/src/ExCSS/Model/Converters.cs
+++ b/src/ExCSS/Model/Converters.cs
@@ -331,6 +331,19 @@ namespace ExCSS
 
         public static readonly IValueConverter AlignSelfConverter = AlignItemsConverter.OrAuto();
 
+        // justify-items / justify-self share align-items/align-self's value grammar for the keywords the
+        // grid engine honors (start/end/center/stretch/normal; baseline falls back to start at layout).
+        public static readonly IValueConverter JustifyItemsConverter = AlignItemsConverter;
+        public static readonly IValueConverter JustifySelfConverter = AlignSelfConverter;
+
+        // place-items / place-content / place-self: <align> <justify>? — one value applies to both axes.
+        public static readonly IValueConverter PlaceItemsConverter =
+            AlignItemsConverter.Periodic(PropertyNames.AlignItems, PropertyNames.JustifyItems);
+        public static readonly IValueConverter PlaceContentConverter =
+            JustifyContentConverter.Periodic(PropertyNames.AlignContent, PropertyNames.JustifyContent);
+        public static readonly IValueConverter PlaceSelfConverter =
+            AlignSelfConverter.Periodic(PropertyNames.AlignSelf, PropertyNames.JustifySelf);
+
         #region Specific
 
         public static readonly IValueConverter OptionalIntegerConverter = IntegerConverter.OrAuto();

--- a/src/ExCSS/Model/ValueBuilder.cs
+++ b/src/ExCSS/Model/ValueBuilder.cs
@@ -65,6 +65,14 @@ namespace ExCSS
                     // descriptor is dropped entirely under strict (non-tolerant) parsing.
                     Add(token);
                     break;
+                case TokenType.SquareBracketOpen:
+                case TokenType.SquareBracketClose:
+                    // A grid <line-names> group is written as [name ...] inside a track list. Like the
+                    // unicode-range Range tokens above, these brackets would otherwise hit the default arm
+                    // and drop the whole value under strict parsing; keep them so the grid grammars can
+                    // validate the line-name groups.
+                    Add(token);
+                    break;
                 case TokenType.Comment:
                     break;
                 default:

--- a/src/ExCSS/StyleProperties/Grid/GridAreaProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/GridAreaProperty.cs
@@ -1,0 +1,19 @@
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid-area</c> shorthand (CSS Grid §8.3.1): <c>&lt;grid-line&gt; [ / &lt;grid-line&gt; ]{0,3}</c>,
+    /// expanding to <c>grid-row-start</c> / <c>grid-column-start</c> / <c>grid-row-end</c> /
+    /// <c>grid-column-end</c>.
+    /// </summary>
+    internal sealed class GridAreaProperty : ShorthandProperty
+    {
+        private static readonly IValueConverter StyleConverter = Converters.GridAreaConverter.OrGlobalValue();
+
+        internal GridAreaProperty()
+            : base(PropertyNames.GridArea)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/GridAutoColumnsProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/GridAutoColumnsProperty.cs
@@ -1,0 +1,15 @@
+namespace ExCSS
+{
+    /// <summary>The <c>grid-auto-columns</c> property (CSS Grid §7.6): the size of implicitly-created columns.</summary>
+    internal sealed class GridAutoColumnsProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = new GridAutoTracksValueConverter().OrDefault();
+
+        internal GridAutoColumnsProperty()
+            : base(PropertyNames.GridAutoColumns)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/GridAutoFlowProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/GridAutoFlowProperty.cs
@@ -1,0 +1,15 @@
+namespace ExCSS
+{
+    /// <summary>The <c>grid-auto-flow</c> property (CSS Grid §7.7): the auto-placement direction and packing.</summary>
+    internal sealed class GridAutoFlowProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = new GridAutoFlowValueConverter().OrDefault();
+
+        internal GridAutoFlowProperty()
+            : base(PropertyNames.GridAutoFlow)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/GridAutoRowsProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/GridAutoRowsProperty.cs
@@ -1,0 +1,15 @@
+namespace ExCSS
+{
+    /// <summary>The <c>grid-auto-rows</c> property (CSS Grid §7.6): the size of implicitly-created rows.</summary>
+    internal sealed class GridAutoRowsProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = new GridAutoTracksValueConverter().OrDefault();
+
+        internal GridAutoRowsProperty()
+            : base(PropertyNames.GridAutoRows)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/GridColumnEndProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/GridColumnEndProperty.cs
@@ -1,0 +1,18 @@
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid-column-end</c> longhand (CSS Grid §8.3), one edge of a grid item's placement.
+    /// Validated by the shared <see cref="GridLineGrammar"/>.
+    /// </summary>
+    internal sealed class GridColumnEndProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = Converters.GridLineConverter.OrDefault();
+
+        internal GridColumnEndProperty()
+            : base(PropertyNames.GridColumnEnd)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/GridColumnProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/GridColumnProperty.cs
@@ -1,0 +1,18 @@
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid-column</c> shorthand (CSS Grid §8.3.1): <c>&lt;grid-line&gt; [ / &lt;grid-line&gt; ]?</c>,
+    /// expanding to <c>grid-column-start</c> / <c>grid-column-end</c>.
+    /// </summary>
+    internal sealed class GridColumnProperty : ShorthandProperty
+    {
+        private static readonly IValueConverter StyleConverter = Converters.GridColumnConverter.OrGlobalValue();
+
+        internal GridColumnProperty()
+            : base(PropertyNames.GridColumn)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/GridColumnStartProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/GridColumnStartProperty.cs
@@ -1,0 +1,18 @@
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid-column-start</c> longhand (CSS Grid §8.3), one edge of a grid item's placement.
+    /// Validated by the shared <see cref="GridLineGrammar"/>.
+    /// </summary>
+    internal sealed class GridColumnStartProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = Converters.GridLineConverter.OrDefault();
+
+        internal GridColumnStartProperty()
+            : base(PropertyNames.GridColumnStart)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/GridProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/GridProperty.cs
@@ -1,0 +1,18 @@
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid</c> shorthand (CSS Grid §7.8): expands to the three <c>grid-template-*</c> longhands plus
+    /// <c>grid-auto-flow</c> / <c>grid-auto-rows</c> / <c>grid-auto-columns</c>.
+    /// </summary>
+    internal sealed class GridProperty : ShorthandProperty
+    {
+        private static readonly IValueConverter StyleConverter = Converters.GridConverter.OrGlobalValue();
+
+        internal GridProperty()
+            : base(PropertyNames.Grid)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/GridRowEndProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/GridRowEndProperty.cs
@@ -1,0 +1,18 @@
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid-row-end</c> longhand (CSS Grid §8.3), one edge of a grid item's placement.
+    /// Validated by the shared <see cref="GridLineGrammar"/>.
+    /// </summary>
+    internal sealed class GridRowEndProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = Converters.GridLineConverter.OrDefault();
+
+        internal GridRowEndProperty()
+            : base(PropertyNames.GridRowEnd)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/GridRowProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/GridRowProperty.cs
@@ -1,0 +1,18 @@
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid-row</c> shorthand (CSS Grid §8.3.1): <c>&lt;grid-line&gt; [ / &lt;grid-line&gt; ]?</c>,
+    /// expanding to <c>grid-row-start</c> / <c>grid-row-end</c>.
+    /// </summary>
+    internal sealed class GridRowProperty : ShorthandProperty
+    {
+        private static readonly IValueConverter StyleConverter = Converters.GridRowConverter.OrGlobalValue();
+
+        internal GridRowProperty()
+            : base(PropertyNames.GridRow)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/GridRowStartProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/GridRowStartProperty.cs
@@ -1,0 +1,18 @@
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid-row-start</c> longhand (CSS Grid §8.3), one edge of a grid item's placement.
+    /// Validated by the shared <see cref="GridLineGrammar"/>.
+    /// </summary>
+    internal sealed class GridRowStartProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = Converters.GridLineConverter.OrDefault();
+
+        internal GridRowStartProperty()
+            : base(PropertyNames.GridRowStart)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/GridTemplateAreasProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/GridTemplateAreasProperty.cs
@@ -1,0 +1,18 @@
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid-template-areas</c> property (CSS Grid §7.3). Validated by the shared
+    /// <see cref="GridTemplateAreasGrammar"/>; the authored text is preserved.
+    /// </summary>
+    internal sealed class GridTemplateAreasProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = new GridTemplateAreasValueConverter().OrDefault();
+
+        internal GridTemplateAreasProperty()
+            : base(PropertyNames.GridTemplateAreas)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/GridTemplateColumnsProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/GridTemplateColumnsProperty.cs
@@ -1,0 +1,18 @@
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid-template-columns</c> property (CSS Grid Layout Module Level 1/2 §7.2). Validated by the
+    /// shared <see cref="GridTrackListGrammar"/>; the authored text is preserved.
+    /// </summary>
+    internal sealed class GridTemplateColumnsProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = new GridTemplateValueConverter().OrDefault();
+
+        internal GridTemplateColumnsProperty()
+            : base(PropertyNames.GridTemplateColumns)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/GridTemplateProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/GridTemplateProperty.cs
@@ -1,0 +1,18 @@
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid-template</c> shorthand (CSS Grid §7.4): expands to <c>grid-template-rows</c> /
+    /// <c>grid-template-columns</c> / <c>grid-template-areas</c>.
+    /// </summary>
+    internal sealed class GridTemplateProperty : ShorthandProperty
+    {
+        private static readonly IValueConverter StyleConverter = Converters.GridTemplateConverter.OrGlobalValue();
+
+        internal GridTemplateProperty()
+            : base(PropertyNames.GridTemplate)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/GridTemplateRowsProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/GridTemplateRowsProperty.cs
@@ -1,0 +1,18 @@
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid-template-rows</c> property (CSS Grid Layout Module Level 1/2 §7.2). Validated by the
+    /// shared <see cref="GridTrackListGrammar"/>; the authored text is preserved.
+    /// </summary>
+    internal sealed class GridTemplateRowsProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = new GridTemplateValueConverter().OrDefault();
+
+        internal GridTemplateRowsProperty()
+            : base(PropertyNames.GridTemplateRows)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/JustifyItemsProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/JustifyItemsProperty.cs
@@ -1,0 +1,15 @@
+namespace ExCSS
+{
+    /// <summary>The <c>justify-items</c> property (CSS Box Alignment): default inline-axis alignment of grid items.</summary>
+    internal sealed class JustifyItemsProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = Converters.JustifyItemsConverter;
+
+        internal JustifyItemsProperty()
+            : base(PropertyNames.JustifyItems)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/JustifySelfProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/JustifySelfProperty.cs
@@ -1,0 +1,15 @@
+namespace ExCSS
+{
+    /// <summary>The <c>justify-self</c> property (CSS Box Alignment): a grid item's own inline-axis alignment.</summary>
+    internal sealed class JustifySelfProperty : Property
+    {
+        private static readonly IValueConverter StyleConverter = Converters.JustifySelfConverter;
+
+        internal JustifySelfProperty()
+            : base(PropertyNames.JustifySelf)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/PlaceContentProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/PlaceContentProperty.cs
@@ -1,0 +1,15 @@
+namespace ExCSS
+{
+    /// <summary>The <c>place-content</c> shorthand (CSS Box Alignment): <c>&lt;align-content&gt; &lt;justify-content&gt;?</c>.</summary>
+    internal sealed class PlaceContentProperty : ShorthandProperty
+    {
+        private static readonly IValueConverter StyleConverter = Converters.PlaceContentConverter.OrGlobalValue();
+
+        internal PlaceContentProperty()
+            : base(PropertyNames.PlaceContent)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/PlaceItemsProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/PlaceItemsProperty.cs
@@ -1,0 +1,15 @@
+namespace ExCSS
+{
+    /// <summary>The <c>place-items</c> shorthand (CSS Box Alignment): <c>&lt;align-items&gt; &lt;justify-items&gt;?</c>.</summary>
+    internal sealed class PlaceItemsProperty : ShorthandProperty
+    {
+        private static readonly IValueConverter StyleConverter = Converters.PlaceItemsConverter.OrGlobalValue();
+
+        internal PlaceItemsProperty()
+            : base(PropertyNames.PlaceItems)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/StyleProperties/Grid/PlaceSelfProperty.cs
+++ b/src/ExCSS/StyleProperties/Grid/PlaceSelfProperty.cs
@@ -1,0 +1,15 @@
+namespace ExCSS
+{
+    /// <summary>The <c>place-self</c> shorthand (CSS Box Alignment): <c>&lt;align-self&gt; &lt;justify-self&gt;?</c>.</summary>
+    internal sealed class PlaceSelfProperty : ShorthandProperty
+    {
+        private static readonly IValueConverter StyleConverter = Converters.PlaceSelfConverter.OrGlobalValue();
+
+        internal PlaceSelfProperty()
+            : base(PropertyNames.PlaceSelf)
+        {
+        }
+
+        internal override IValueConverter Converter => StyleConverter;
+    }
+}

--- a/src/ExCSS/ValueConverters/GridAreaShorthandValueConverter.cs
+++ b/src/ExCSS/ValueConverters/GridAreaShorthandValueConverter.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid-area</c> shorthand: <c>&lt;grid-line&gt; [ / &lt;grid-line&gt; ]{0,3}</c> in the order
+    /// row-start / column-start / row-end / column-end. Implements the CSS Grid §8.3.1 omitted-value copy
+    /// rule — a bare <c>&lt;custom-ident&gt;</c> propagates to the paired/all edges, so <c>grid-area: main</c>
+    /// fills the whole <c>main</c> area, while <c>grid-area: 2</c> leaves the other edges <c>auto</c>.
+    /// </summary>
+    internal sealed class GridAreaShorthandValueConverter : IValueConverter
+    {
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            var c = GridPlacementShorthand.Split(value, maxComponents: 4);
+            if (c is null) return null;
+
+            var rowStart = c[0];
+            // column-start omitted → if row-start is a bare custom-ident, all four take it; else auto.
+            var colStart = c.Count > 1 ? c[1]
+                : rowStart.IsBareCustomIdent ? rowStart : (GridPlacementShorthand.Component?)null;
+            // row-end omitted → copy a bare custom-ident row-start, else auto.
+            var rowEnd = c.Count > 2 ? c[2]
+                : rowStart.IsBareCustomIdent ? rowStart : (GridPlacementShorthand.Component?)null;
+            // column-end omitted → copy a bare custom-ident column-start, else auto.
+            var colEnd = c.Count > 3 ? c[3]
+                : colStart is { IsBareCustomIdent: true } ? colStart : (GridPlacementShorthand.Component?)null;
+
+            var map = new Dictionary<string, IReadOnlyList<Token>>
+            {
+                [PropertyNames.GridRowStart] = rowStart.Tokens,
+                [PropertyNames.GridColumnStart] = GridPlacementShorthand.Or(colStart),
+                [PropertyNames.GridRowEnd] = GridPlacementShorthand.Or(rowEnd),
+                [PropertyNames.GridColumnEnd] = GridPlacementShorthand.Or(colEnd),
+            };
+            return new MappedShorthandValue(map, value);
+        }
+
+        public IPropertyValue Construct(Property[] properties) => properties.Guard<MappedShorthandValue>();
+    }
+}

--- a/src/ExCSS/ValueConverters/GridAutoFlowValueConverter.cs
+++ b/src/ExCSS/ValueConverters/GridAutoFlowValueConverter.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// Validates a <c>grid-auto-flow</c> value (CSS Grid §7.7): <c>[ row | column ] || dense</c> — one of
+    /// <c>row</c>/<c>column</c> optionally combined with <c>dense</c>, in either order. The authored text is
+    /// preserved.
+    /// </summary>
+    internal sealed class GridAutoFlowValueConverter : IValueConverter
+    {
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            var tokens = value.ToArray();
+            var idents = tokens.Where(t => t.Type != TokenType.Whitespace).ToArray();
+            if (idents.Length is < 1 or > 2 || idents.Any(t => t.Type != TokenType.Ident))
+                return null;
+
+            var hasAxis = false;
+            var hasDense = false;
+            foreach (var t in idents)
+            {
+                if (t.Data.Isi(Keywords.Row) || t.Data.Isi(Keywords.Column))
+                {
+                    if (hasAxis) return null; // row and column are mutually exclusive
+                    hasAxis = true;
+                }
+                else if (t.Data.Isi(Keywords.Dense))
+                {
+                    if (hasDense) return null;
+                    hasDense = true;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            return new GridAutoFlowValue(tokens);
+        }
+
+        public IPropertyValue Construct(Property[] properties) => properties.Guard<GridAutoFlowValue>();
+
+        private sealed class GridAutoFlowValue : IPropertyValue
+        {
+            public GridAutoFlowValue(IEnumerable<Token> tokens)
+            {
+                Original = new TokenValue(tokens);
+            }
+
+            public string CssText => Original.Text;
+            public TokenValue Original { get; }
+            public TokenValue ExtractFor(string name) => Original;
+        }
+    }
+}

--- a/src/ExCSS/ValueConverters/GridAutoTracksValueConverter.cs
+++ b/src/ExCSS/ValueConverters/GridAutoTracksValueConverter.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// Validates a <c>grid-auto-columns</c>/<c>grid-auto-rows</c> value: a <c>&lt;track-size&gt;+</c> list
+    /// (no <c>repeat()</c>) via the shared <see cref="GridTrackListGrammar"/>. The authored text is preserved.
+    /// </summary>
+    internal sealed class GridAutoTracksValueConverter : IValueConverter
+    {
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            var tokens = value.ToArray();
+            return GridTrackListGrammar.TryParseTrackSizeList(tokens.Where(t => t.Type != TokenType.Whitespace).ToArray()) is null
+                ? null
+                : new GridAutoTracksValue(tokens);
+        }
+
+        public IPropertyValue Construct(Property[] properties) => properties.Guard<GridAutoTracksValue>();
+
+        private sealed class GridAutoTracksValue : IPropertyValue
+        {
+            public GridAutoTracksValue(IEnumerable<Token> tokens)
+            {
+                Original = new TokenValue(tokens);
+            }
+
+            public string CssText => Original.Text;
+            public TokenValue Original { get; }
+            public TokenValue ExtractFor(string name) => Original;
+        }
+    }
+}

--- a/src/ExCSS/ValueConverters/GridColumnRowShorthandValueConverter.cs
+++ b/src/ExCSS/ValueConverters/GridColumnRowShorthandValueConverter.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid-column</c> / <c>grid-row</c> shorthand: <c>&lt;grid-line&gt; [ / &lt;grid-line&gt; ]?</c>
+    /// expanding to the axis's <c>-start</c>/<c>-end</c> longhands. Implements the CSS Grid §8.3.1
+    /// omitted-value copy rule that the generic <c>WithOrder(...).Option()</c> DSL cannot: when the end is
+    /// omitted, it copies a bare <c>&lt;custom-ident&gt;</c> start (so <c>grid-column: main</c> spans the
+    /// whole <c>main</c> area) but leaves a line number / span as <c>auto</c>.
+    /// </summary>
+    internal sealed class GridColumnRowShorthandValueConverter : IValueConverter
+    {
+        private readonly string _startName;
+        private readonly string _endName;
+
+        public GridColumnRowShorthandValueConverter(string startName, string endName)
+        {
+            _startName = startName;
+            _endName = endName;
+        }
+
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            var components = GridPlacementShorthand.Split(value, maxComponents: 2);
+            if (components is null) return null;
+
+            var start = components[0];
+            // end omitted → copy a bare custom-ident start, else auto.
+            var end = components.Count > 1 ? components[1]
+                : start.IsBareCustomIdent ? start : (GridPlacementShorthand.Component?)null;
+
+            var map = new Dictionary<string, IReadOnlyList<Token>>
+            {
+                [_startName] = start.Tokens,
+                [_endName] = GridPlacementShorthand.Or(end),
+            };
+            return new MappedShorthandValue(map, value);
+        }
+
+        public IPropertyValue Construct(Property[] properties) => properties.Guard<MappedShorthandValue>();
+    }
+}

--- a/src/ExCSS/ValueConverters/GridLineValueConverter.cs
+++ b/src/ExCSS/ValueConverters/GridLineValueConverter.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// Validates a single grid <c>&lt;grid-line&gt;</c> (<c>grid-column-start</c>/<c>-end</c>,
+    /// <c>grid-row-start</c>/<c>-end</c>) through the shared <see cref="GridLineGrammar"/> — <c>auto</c>, an
+    /// integer line, or <c>span N</c>. The authored text is preserved.
+    /// </summary>
+    internal sealed class GridLineValueConverter : IValueConverter
+    {
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            var tokens = value.ToArray();
+            return GridLineGrammar.TryParse(tokens.Where(t => t.Type != TokenType.Whitespace).ToArray()) is null
+                ? null
+                : new GridLineValue(tokens);
+        }
+
+        public IPropertyValue Construct(Property[] properties)
+        {
+            return properties.Guard<GridLineValue>();
+        }
+
+        private sealed class GridLineValue : IPropertyValue
+        {
+            public GridLineValue(IEnumerable<Token> tokens)
+            {
+                Original = new TokenValue(tokens);
+            }
+
+            public string CssText => Original.Text;
+
+            public TokenValue Original { get; }
+
+            public TokenValue ExtractFor(string name) => Original;
+        }
+    }
+}

--- a/src/ExCSS/ValueConverters/GridPlacementShorthand.cs
+++ b/src/ExCSS/ValueConverters/GridPlacementShorthand.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>Shared helpers for the grid placement shorthands (<c>grid-column</c>/<c>grid-row</c>/
+    /// <c>grid-area</c>): splitting a value on <c>/</c> into <c>&lt;grid-line&gt;</c> components, validating
+    /// each, and building the omitted-value copy result (CSS Grid §8.3.1).</summary>
+    internal static class GridPlacementShorthand
+    {
+        /// <summary>A parsed <c>&lt;grid-line&gt;</c> component: its authored tokens and whether it is a bare
+        /// <c>&lt;custom-ident&gt;</c> (the only form the omitted-value copy rule propagates).</summary>
+        internal struct Component
+        {
+            public IReadOnlyList<Token> Tokens { get; set; }
+            public bool IsBareCustomIdent { get; set; }
+        }
+
+        private static readonly Token AutoToken = new(TokenType.Ident, Keywords.Auto, TextPosition.Empty);
+
+        /// <summary>Splits the value on top-level <c>/</c> delimiters into <c>&lt;grid-line&gt;</c> components,
+        /// validating each via <see cref="GridLineGrammar"/>. Returns null on any invalid component or an
+        /// out-of-range component count.</summary>
+        internal static List<Component> Split(IEnumerable<Token> value, int maxComponents)
+        {
+            var groups = new List<List<Token>> { new List<Token>() };
+            foreach (var token in value)
+            {
+                if (token.Type == TokenType.Whitespace) { groups[groups.Count - 1].Add(token); continue; }
+                if (token.Type == TokenType.Delim && token.Data == "/") { groups.Add(new List<Token>()); continue; }
+                groups[groups.Count - 1].Add(token);
+            }
+
+            var components = new List<Component>(groups.Count);
+            foreach (var group in groups)
+            {
+                var significant = group.Where(t => t.Type != TokenType.Whitespace).ToArray();
+                var parsed = GridLineGrammar.TryParse(significant);
+                if (parsed is null) return null;
+                // Preserve internal whitespace in the stored tokens (only trim the ends) so a two-token
+                // component like "span 2" round-trips as "span 2", not "span2" (which would re-lex as one
+                // ident). A bare <custom-ident> is a single ident token that parsed to a named (non-Nth) line.
+                components.Add(new Component
+                {
+                    Tokens = Trim(group),
+                    IsBareCustomIdent = significant.Length == 1 && significant[0].Type == TokenType.Ident && parsed.Name != null
+                });
+            }
+
+            return components.Count >= 1 && components.Count <= maxComponents ? components : null;
+        }
+
+        /// <summary>The tokens for a longhand: the specified component's tokens, or <c>auto</c> when omitted.</summary>
+        internal static IReadOnlyList<Token> Or(Component? component) =>
+            component is { } c ? c.Tokens : new[] { AutoToken };
+
+        /// <summary>Drops leading and trailing whitespace tokens, keeping internal whitespace.</summary>
+        private static IReadOnlyList<Token> Trim(List<Token> group)
+        {
+            var start = 0;
+            var end = group.Count - 1;
+            while (start <= end && group[start].Type == TokenType.Whitespace) start++;
+            while (end >= start && group[end].Type == TokenType.Whitespace) end--;
+            return group.GetRange(start, end - start + 1);
+        }
+    }
+
+    /// <summary>A shorthand <see cref="IPropertyValue"/> that emits a precomputed token stream for each of
+    /// its longhands (via <see cref="ExtractFor"/>), used by the grid placement shorthands.</summary>
+    internal sealed class MappedShorthandValue : IPropertyValue
+    {
+        private readonly IReadOnlyDictionary<string, IReadOnlyList<Token>> _map;
+
+        public MappedShorthandValue(IReadOnlyDictionary<string, IReadOnlyList<Token>> map, IEnumerable<Token> original)
+        {
+            _map = map;
+            Original = new TokenValue(original);
+        }
+
+        public string CssText => Original.Text;
+        public TokenValue Original { get; }
+
+        public TokenValue ExtractFor(string name) =>
+            _map.TryGetValue(name, out var tokens) ? new TokenValue(tokens) : TokenValue.Empty;
+    }
+}

--- a/src/ExCSS/ValueConverters/GridShorthandValueConverter.cs
+++ b/src/ExCSS/ValueConverters/GridShorthandValueConverter.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid</c> shorthand (CSS Grid §7.8): either a <c>&lt;grid-template&gt;</c>, or one of the two
+    /// auto-flow forms
+    /// <c>&lt;grid-template-rows&gt; / [ auto-flow &amp;&amp; dense? ] &lt;grid-auto-columns&gt;?</c> and
+    /// <c>[ auto-flow &amp;&amp; dense? ] &lt;grid-auto-rows&gt;? / &lt;grid-template-columns&gt;</c>. Expands to
+    /// the three <c>grid-template-*</c> longhands plus <c>grid-auto-flow</c>/<c>-rows</c>/<c>-columns</c>;
+    /// every longhand it doesn't set is reset to its initial value (an absent slice — §7.8).
+    /// </summary>
+    internal sealed class GridShorthandValueConverter : IValueConverter
+    {
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            // NB: the domain-specific IEnumerable<Token>.ToList() extension splits on commas; materialize the
+            // flat token list explicitly instead.
+            var tokens = new List<Token>(value);
+
+            // Form 1: <grid-template>. The three template longhands are set; grid-auto-flow/-rows/-columns
+            // are omitted here so they reset to their initial values (row / auto / auto).
+            if (GridTemplateShorthand.TryParseTemplate(tokens, out var rows, out var columns, out var areas))
+            {
+                var templateMap = new Dictionary<string, IReadOnlyList<Token>>();
+                if (rows is not null) templateMap[PropertyNames.GridTemplateRows] = rows;
+                if (columns is not null) templateMap[PropertyNames.GridTemplateColumns] = columns;
+                if (areas is not null) templateMap[PropertyNames.GridTemplateAreas] = areas;
+                return new MappedShorthandValue(templateMap, tokens);
+            }
+
+            // Forms 2/3: an auto-flow form — requires exactly one top-level '/'.
+            var groups = GridTemplateShorthand.SplitTopLevelSlash(tokens);
+            if (groups.Count != 2) return null;
+
+            var leftRaw = groups[0];
+            var rightRaw = groups[1];
+            var left = GridTemplateShorthand.Significant(leftRaw);
+            var right = GridTemplateShorthand.Significant(rightRaw);
+
+            var leftHasFlow = left.Any(t => t.Type == TokenType.Ident && t.Data.Isi(Keywords.AutoFlow));
+            var rightHasFlow = right.Any(t => t.Type == TokenType.Ident && t.Data.Isi(Keywords.AutoFlow));
+            if (leftHasFlow == rightHasFlow) return null; // exactly one side carries auto-flow
+
+            var map = new Dictionary<string, IReadOnlyList<Token>>();
+
+            if (rightHasFlow)
+            {
+                // <grid-template-rows> / [ auto-flow && dense? ] <grid-auto-columns>?
+                var rowsSlice = GridTemplateShorthand.TryTemplateAxis(leftRaw);
+                if (rowsSlice is null) return null;
+                if (!GridTemplateShorthand.TryParseAutoFlowSide(rightRaw, out var dense, out var autoColumns)) return null;
+
+                map[PropertyNames.GridTemplateRows] = rowsSlice;
+                map[PropertyNames.GridAutoFlow] = GridTemplateShorthand.BuildAutoFlow(column: true, dense);
+                if (autoColumns is not null) map[PropertyNames.GridAutoColumns] = autoColumns;
+            }
+            else
+            {
+                // [ auto-flow && dense? ] <grid-auto-rows>? / <grid-template-columns>
+                var columnsSlice = GridTemplateShorthand.TryTemplateAxis(rightRaw);
+                if (columnsSlice is null) return null;
+                if (!GridTemplateShorthand.TryParseAutoFlowSide(leftRaw, out var dense, out var autoRows)) return null;
+
+                map[PropertyNames.GridTemplateColumns] = columnsSlice;
+                map[PropertyNames.GridAutoFlow] = GridTemplateShorthand.BuildAutoFlow(column: false, dense);
+                if (autoRows is not null) map[PropertyNames.GridAutoRows] = autoRows;
+            }
+
+            return new MappedShorthandValue(map, tokens);
+        }
+
+        public IPropertyValue Construct(Property[] properties) => properties.Guard<MappedShorthandValue>();
+    }
+}

--- a/src/ExCSS/ValueConverters/GridTemplateAreasValueConverter.cs
+++ b/src/ExCSS/ValueConverters/GridTemplateAreasValueConverter.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// Validates a <c>grid-template-areas</c> value: the keyword <c>none</c> or a rectangular grid of quoted
+    /// strings accepted by the shared <see cref="GridTemplateAreasGrammar"/> (equal columns per row, each
+    /// named area a single filled rectangle). The authored text is preserved.
+    /// </summary>
+    internal sealed class GridTemplateAreasValueConverter : IValueConverter
+    {
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            var tokens = value.Where(t => t.Type != TokenType.Whitespace).ToArray();
+
+            var isNone = tokens.Length == 1 && tokens[0].Type == TokenType.Ident && tokens[0].Data.Isi(Keywords.None);
+
+            if (!isNone && GridTemplateAreasGrammar.TryParse(tokens) is null)
+                return null;
+
+            return new GridTemplateAreasValue(value);
+        }
+
+        public IPropertyValue Construct(Property[] properties) => properties.Guard<GridTemplateAreasValue>();
+
+        private sealed class GridTemplateAreasValue : IPropertyValue
+        {
+            public GridTemplateAreasValue(IEnumerable<Token> tokens)
+            {
+                Original = new TokenValue(tokens);
+            }
+
+            public string CssText => Original.Text;
+            public TokenValue Original { get; }
+            public TokenValue ExtractFor(string name) => Original;
+        }
+    }
+}

--- a/src/ExCSS/ValueConverters/GridTemplateShorthand.cs
+++ b/src/ExCSS/ValueConverters/GridTemplateShorthand.cs
@@ -1,0 +1,263 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// Shared parsing for the CSS Grid mega-shorthands <c>grid-template</c> (CSS Grid 2 §7.4) and
+    /// <c>grid</c> (§7.8): splitting the value on the top-level <c>/</c>, running the areas-form row scanner,
+    /// and validating each partitioned slice against the existing longhand grammars
+    /// (<see cref="GridTrackListGrammar"/>/<see cref="GridTemplateAreasGrammar"/>). The two converters stay
+    /// thin over this helper.
+    /// </summary>
+    internal static class GridTemplateShorthand
+    {
+        internal static readonly Token AutoToken = new(TokenType.Ident, Keywords.Auto, TextPosition.Empty);
+        private static readonly Token NoneToken = new(TokenType.Ident, Keywords.None, TextPosition.Empty);
+
+        /// <summary>
+        /// Splits the flat token stream on top-level <c>/</c> delimiters, preserving each group's
+        /// whitespace. No bracket/paren depth counter is needed: functions are single
+        /// <see cref="FunctionToken"/>s (their args nested) and <c>[name]</c> groups hold only idents, so a
+        /// <c>/</c> never appears nested at the flat level (same reasoning as
+        /// <see cref="GridPlacementShorthand"/>).
+        /// </summary>
+        internal static List<List<Token>> SplitTopLevelSlash(IEnumerable<Token> value)
+        {
+            var groups = new List<List<Token>> { new List<Token>() };
+
+            foreach (var token in value)
+            {
+                if (token.Type == TokenType.Delim && token.Data == "/") groups.Add(new List<Token>());
+                else groups[groups.Count - 1].Add(token);
+            }
+
+            return groups;
+        }
+
+        internal static Token[] Significant(IEnumerable<Token> tokens) =>
+            tokens.Where(t => t.Type != TokenType.Whitespace).ToArray();
+
+        /// <summary>
+        /// Validates one axis of the <c>&lt;rows&gt; / &lt;columns&gt;</c> form — a <c>&lt;track-list&gt;</c> or
+        /// the keyword <c>none</c> (both accepted by the <c>grid-template-rows</c>/<c>-columns</c> longhands) —
+        /// returning the edge-trimmed slice, or <see langword="null"/> if invalid.
+        /// </summary>
+        internal static IReadOnlyList<Token> TryTemplateAxis(IReadOnlyList<Token> raw)
+        {
+            var significant = Significant(raw);
+            if (significant.Length == 0) return null;
+            if (significant.Length == 1 && significant[0].Type == TokenType.Ident && significant[0].Data.Isi(Keywords.None))
+                return Trim(raw);
+            return GridTrackListGrammar.TryParse(raw) is not null ? Trim(raw) : null;
+        }
+
+        private static bool ContainsRepeat(IEnumerable<Token> significant) =>
+            significant.Any(t => t is FunctionToken fn && fn.Data.Isi(FunctionNames.Repeat));
+
+        /// <summary>Drops leading/trailing whitespace tokens, keeping internal whitespace.</summary>
+        internal static IReadOnlyList<Token> Trim(IReadOnlyList<Token> tokens)
+        {
+            var start = 0;
+            var end = tokens.Count - 1;
+            while (start <= end && tokens[start].Type == TokenType.Whitespace) start++;
+            while (end >= start && tokens[end].Type == TokenType.Whitespace) end--;
+
+            var result = new List<Token>(end - start + 1);
+            for (var i = start; i <= end; i++) result.Add(tokens[i]);
+            return result;
+        }
+
+        /// <summary>The <c>grid-auto-flow</c> token slice for the <c>grid</c> auto-flow forms.</summary>
+        internal static IReadOnlyList<Token> BuildAutoFlow(bool column, bool dense)
+        {
+            var flow = new List<Token> { new Token(TokenType.Ident, column ? Keywords.Column : Keywords.Row, TextPosition.Empty) };
+            if (dense)
+            {
+                flow.Add(Token.Whitespace);
+                flow.Add(new Token(TokenType.Ident, Keywords.Dense, TextPosition.Empty));
+            }
+            return flow;
+        }
+
+        /// <summary>
+        /// Parses a <c>grid-template</c> value (§7.4) into the three longhand slices. A <see langword="null"/>
+        /// out-slice means "omit it" (the longhand resets to its initial value). Returns <see langword="false"/>
+        /// for an invalid value (the whole declaration is then dropped).
+        /// </summary>
+        internal static bool TryParseTemplate(IEnumerable<Token> value,
+            out IReadOnlyList<Token> rows, out IReadOnlyList<Token> columns, out IReadOnlyList<Token> areas)
+        {
+            rows = columns = areas = null;
+
+            var groups = SplitTopLevelSlash(value);
+            if (groups.Count > 2) return false; // at most one top-level '/'
+
+            var leftRaw = groups[0];
+            var rightRaw = groups.Count == 2 ? groups[1] : null;
+            var left = Significant(leftRaw);
+            var right = rightRaw is null ? null : Significant(rightRaw);
+
+            // grid-template: none  →  all three longhands none.
+            if (right is null && left.Length == 1 && left[0].Type == TokenType.Ident && left[0].Data.Isi(Keywords.None))
+            {
+                rows = columns = areas = new[] { NoneToken };
+                return true;
+            }
+
+            if (left.Length == 0) return false;
+
+            if (left.Any(t => t.Type == TokenType.String))
+            {
+                // Areas form: [ <line-names>? <string> <track-size>? <line-names>? ]+ [ / <explicit-track-list> ]?
+                if (!TryScanAreasForm(left, out var rowsTokens, out var areaTokens)) return false;
+                if (GridTemplateAreasGrammar.TryParse(areaTokens) is null) return false;
+                if (GridTrackListGrammar.TryParse(rowsTokens) is null) return false;
+
+                rows = rowsTokens;
+                areas = areaTokens;
+
+                if (rightRaw is not null)
+                {
+                    // The trailing columns are an <explicit-track-list> — a <track-list> with no repeat().
+                    if (right.Length == 0 || ContainsRepeat(right) || GridTrackListGrammar.TryParse(rightRaw) is null)
+                        return false;
+                    columns = Trim(rightRaw);
+                }
+
+                return true;
+            }
+
+            // rows / columns form: requires the slash; each side is a <track-list> or `none`.
+            if (rightRaw is null) return false;
+            var rowsSlice = TryTemplateAxis(leftRaw);
+            var columnsSlice = TryTemplateAxis(rightRaw);
+            if (rowsSlice is null || columnsSlice is null) return false;
+
+            rows = rowsSlice;
+            columns = columnsSlice;
+            return true;
+        }
+
+        /// <summary>
+        /// Scans the areas-form left side, synthesizing the <c>grid-template-rows</c> track list
+        /// (<paramref name="rowsOut"/>) and collecting the ordered <c>&lt;string&gt;</c> area tokens
+        /// (<paramref name="areaStrings"/>). Every emitted token is whitespace-separated so both round-trip
+        /// serialization (via <c>ToText</c>) and re-parsing are valid.
+        /// </summary>
+        private static bool TryScanAreasForm(Token[] toks, out List<Token> rowsOut, out List<Token> areaStrings)
+        {
+            rowsOut = new List<Token>();
+            areaStrings = new List<Token>();
+            var sawString = false;
+
+            var i = 0;
+            while (i < toks.Length)
+            {
+                var t = toks[i];
+
+                if (t.Type == TokenType.SquareBracketOpen)
+                {
+                    // Copy the [ name … ] line-name group (idents only) at the current line position, kept
+                    // compact as `[a b]` (edge spaces omitted, single space between names).
+                    if (rowsOut.Count > 0) rowsOut.Add(Token.Whitespace);
+                    rowsOut.Add(t);
+                    i++;
+                    var firstName = true;
+                    while (i < toks.Length && toks[i].Type != TokenType.SquareBracketClose)
+                    {
+                        if (toks[i].Type != TokenType.Ident) return false;
+                        if (!firstName) rowsOut.Add(Token.Whitespace);
+                        rowsOut.Add(toks[i]);
+                        firstName = false;
+                        i++;
+                    }
+                    if (i >= toks.Length) return false; // unclosed '['
+                    rowsOut.Add(toks[i]); // ']'
+                    i++;
+                    continue;
+                }
+
+                if (t.Type == TokenType.String)
+                {
+                    Emit(areaStrings, t);
+                    sawString = true;
+                    i++;
+
+                    // Optional single-token <track-size> for this row (else the row track is `auto`).
+                    if (i < toks.Length && toks[i].Type != TokenType.SquareBracketOpen && toks[i].Type != TokenType.String)
+                    {
+                        if (GridTrackListGrammar.TryParseTrackSizeList(new[] { toks[i] }) is null) return false;
+                        Emit(rowsOut, toks[i]);
+                        i++;
+                    }
+                    else
+                    {
+                        Emit(rowsOut, AutoToken);
+                    }
+
+                    continue;
+                }
+
+                // A track-size or stray token with no preceding string at this position is invalid.
+                return false;
+            }
+
+            return sawString;
+        }
+
+        private static void Emit(List<Token> tokens, Token token)
+        {
+            if (tokens.Count > 0) tokens.Add(Token.Whitespace);
+            tokens.Add(token);
+        }
+
+        /// <summary>
+        /// Parses the <c>[ auto-flow &amp;&amp; dense? ] &lt;track-size&gt;*</c> side of a <c>grid</c> auto-flow
+        /// form. Returns <see langword="false"/> when <c>auto-flow</c> is absent or the value is malformed;
+        /// <paramref name="autoTracks"/> is null when the optional track-size list is omitted (reset to initial).
+        /// </summary>
+        internal static bool TryParseAutoFlowSide(IReadOnlyList<Token> raw, out bool dense, out IReadOnlyList<Token> autoTracks)
+        {
+            dense = false;
+            autoTracks = null;
+            var hasAutoFlow = false;
+
+            var i = 0;
+            while (i < raw.Count)
+            {
+                var t = raw[i];
+                if (t.Type == TokenType.Whitespace) { i++; continue; }
+                if (t.Type == TokenType.Ident && t.Data.Isi(Keywords.AutoFlow))
+                {
+                    if (hasAutoFlow) return false;
+                    hasAutoFlow = true;
+                    i++;
+                    continue;
+                }
+                if (t.Type == TokenType.Ident && t.Data.Isi(Keywords.Dense))
+                {
+                    if (dense) return false;
+                    dense = true;
+                    i++;
+                    continue;
+                }
+                break;
+            }
+
+            if (!hasAutoFlow) return false;
+
+            var rest = new List<Token>();
+            for (; i < raw.Count; i++) rest.Add(raw[i]);
+            var trimmed = Trim(rest);
+
+            if (trimmed.Count > 0)
+            {
+                if (GridTrackListGrammar.TryParseTrackSizeList(trimmed) is null) return false;
+                autoTracks = trimmed;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/ExCSS/ValueConverters/GridTemplateShorthandValueConverter.cs
+++ b/src/ExCSS/ValueConverters/GridTemplateShorthandValueConverter.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// The <c>grid-template</c> shorthand (CSS Grid §7.4), expanding to <c>grid-template-rows</c> /
+    /// <c>grid-template-columns</c> / <c>grid-template-areas</c>. An omitted axis is reset to its initial
+    /// value (<c>none</c>) by <see cref="ShorthandProperty.Export"/> when its slice is absent.
+    /// </summary>
+    internal sealed class GridTemplateShorthandValueConverter : IValueConverter
+    {
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            if (!GridTemplateShorthand.TryParseTemplate(value, out var rows, out var columns, out var areas))
+                return null;
+
+            var map = new Dictionary<string, IReadOnlyList<Token>>();
+            if (rows is not null) map[PropertyNames.GridTemplateRows] = rows;
+            if (columns is not null) map[PropertyNames.GridTemplateColumns] = columns;
+            if (areas is not null) map[PropertyNames.GridTemplateAreas] = areas;
+
+            return new MappedShorthandValue(map, value);
+        }
+
+        public IPropertyValue Construct(Property[] properties) => properties.Guard<MappedShorthandValue>();
+    }
+}

--- a/src/ExCSS/ValueConverters/GridTemplateValueConverter.cs
+++ b/src/ExCSS/ValueConverters/GridTemplateValueConverter.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ExCSS
+{
+    /// <summary>
+    /// Validates a <c>grid-template-columns</c>/<c>grid-template-rows</c> value: accepts the keyword
+    /// <c>none</c> or any <c>&lt;track-list&gt;</c> the shared <see cref="GridTrackListGrammar"/> recognizes
+    /// (lengths, %, <c>fr</c>, <c>auto</c>, <c>min-content</c>/<c>max-content</c>, <c>minmax()</c>,
+    /// <c>fit-content()</c>, <c>repeat()</c>), rejecting everything else so an invalid template is dropped
+    /// at parse time. The authored text is preserved verbatim (mirrors
+    /// <see cref="AspectRatioValueConverter"/>).
+    /// </summary>
+    internal sealed class GridTemplateValueConverter : IValueConverter
+    {
+        public IPropertyValue Convert(IEnumerable<Token> value)
+        {
+            var tokens = value.Where(t => t.Type != TokenType.Whitespace).ToArray();
+
+            var isNone = tokens.Length == 1 && tokens[0].Type == TokenType.Ident && tokens[0].Data.Isi(Keywords.None);
+
+            if (!isNone && GridTrackListGrammar.TryParse(tokens) is null)
+                return null;
+
+            return new GridTemplateValue(value);
+        }
+
+        public IPropertyValue Construct(Property[] properties)
+        {
+            return properties.Guard<GridTemplateValue>();
+        }
+
+        private sealed class GridTemplateValue : IPropertyValue
+        {
+            public GridTemplateValue(IEnumerable<Token> tokens)
+            {
+                Original = new TokenValue(tokens);
+            }
+
+            public string CssText => Original.Text;
+
+            public TokenValue Original { get; }
+
+            public TokenValue ExtractFor(string name) => Original;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds **CSS Grid** parsing to ExCSS ([CSS Grid Layout Level 1](https://www.w3.org/TR/css-grid-1/) / [Level 2](https://www.w3.org/TR/css-grid-2/)): value grammars, properties, converters, and serialization.

Delivered as 7 ordered commits:

1. **Track-list parsing** — `GridTrackListGrammar` (lengths, `%`, `fr`, `auto`, `min-content`/`max-content`, `minmax()`, `fit-content()`, `repeat()` incl. `auto-fill`/`auto-fit`); `grid-template-columns`/`-rows`, `grid-auto-columns`/`-rows`/`grid-auto-flow`.
2. **Line-based placement** — `GridLineGrammar` (`auto` | `<integer>` | `span n` | named); `grid-column`/`-row`-`start`/`-end` longhands + the `grid-column`/`grid-row`/`grid-area` shorthands (with the §8.3.1 omitted-value copy rule).
3. **Box alignment** — `justify-items`/`justify-self` + `place-items`/`place-content`/`place-self` (reusing the existing `align-*`/`justify-content` converters).
4. **`grid-template-areas`** — `GridTemplateAreasGrammar` (validates rectangular named areas). Also makes `ValueBuilder` accept `[`/`]` tokens in a value (prerequisite for named lines; mirrors the existing unicode-range Range-token handling).
5. **Named grid lines** — `[name]` groups in track lists + `<custom-ident>`/Nth named-line placement.
6. **`subgrid`** — accepted in the track-list grammar (`subgrid [ <line-name-list> ]?`).
7. **`grid` / `grid-template` mega-shorthands** — via `GridTemplateShorthand`; excluded from serialization reconstruction so `ToCss()` never re-collapses the longhands.

## Design

Every grid value-converter validates via the grammar and preserves the authored text (mirroring the existing `AspectRatioValueConverter`). The grammar model types (`GridTemplate`, `GridLine`, `GridAreas`) back the grammars and tests.

## Portability

Builds clean across all 8 target frameworks (0 errors/warnings). C# stays within LangVersion 9.

## Tests

`GridTrackListGrammarTests`, `GridLineGrammarTests`, `GridTemplateAreasGrammarTests`, `GridTemplateShorthandTests`, plus per-feature property round-trip tests — 174 new cases. Full suite green at 1690 passing, no regressions.
